### PR TITLE
feat: Add Simple Policy Optimization (SPO) Implementation

### DIFF
--- a/sota-implementations/spo/config_mujoco.yaml
+++ b/sota-implementations/spo/config_mujoco.yaml
@@ -1,0 +1,44 @@
+# SPO (Simple Policy Optimization) configuration for MuJoCo
+# Based on hyperparameters from "Simple Policy Optimization" (https://arxiv.org/abs/2401.16025)
+
+# task and env
+env:
+  env_name: HalfCheetah-v4
+
+# collector
+collector:
+  frames_per_batch: 2048
+  total_frames: 1_000_000
+
+# logger
+logger:
+  backend: wandb
+  project_name: torchrl_example_spo
+  group_name: null
+  exp_name: Mujoco_SPO
+  test_interval: 1_000_000
+  num_test_episodes: 5
+  video: False
+
+# Optim
+optim:
+  lr: 3e-4
+  weight_decay: 0.0
+  anneal_lr: True
+  device:
+
+# loss
+loss:
+  gamma: 0.99
+  mini_batch_size: 512
+  spo_epochs: 10
+  gae_lambda: 0.95
+  epsilon: 0.2
+  critic_coef: 0.5
+  entropy_coef: 0.0
+  loss_critic_type: smooth_l1
+
+compile:
+  compile: False
+  compile_mode:
+  cudagraphs: False

--- a/sota-implementations/spo/spo_mujoco.py
+++ b/sota-implementations/spo/spo_mujoco.py
@@ -1,0 +1,297 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This script reproduces the Simple Policy Optimization (SPO) Algorithm
+results from Lu et al. 2024 for MuJoCo Environments.
+
+Paper: "Simple Policy Optimization" (https://arxiv.org/abs/2401.16025)
+
+SPO modifies PPO's clipping objective with a quadratic penalty term to better
+constrain the probability ratio within the trust region, achieving stronger
+theoretical guarantees while maintaining computational simplicity.
+"""
+from __future__ import annotations
+
+import warnings
+
+import hydra
+from torchrl._utils import compile_with_warmup
+
+
+@hydra.main(config_path="", config_name="config_mujoco", version_base="1.1")
+def main(cfg: DictConfig):  # noqa: F821
+
+    import torch.optim
+    import tqdm
+
+    from tensordict import TensorDict
+    from tensordict.nn import CudaGraphModule
+
+    from torchrl._utils import timeit
+    from torchrl.collectors import SyncDataCollector
+    from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
+    from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
+    from torchrl.envs import ExplorationType, set_exploration_type
+    from torchrl.objectives import group_optimizers, SPOLoss
+    from torchrl.objectives.value.advantages import GAE
+    from torchrl.record import VideoRecorder
+    from torchrl.record.loggers import generate_exp_name, get_logger
+    from utils_mujoco import eval_model, make_env, make_ppo_models
+
+    torch.set_float32_matmul_precision("high")
+
+    device = cfg.optim.device
+    if device in ("", None):
+        if torch.cuda.is_available():
+            device = "cuda:0"
+        else:
+            device = "cpu"
+    device = torch.device(device)
+
+    num_mini_batches = cfg.collector.frames_per_batch // cfg.loss.mini_batch_size
+    total_network_updates = (
+        (cfg.collector.total_frames // cfg.collector.frames_per_batch)
+        * cfg.loss.spo_epochs
+        * num_mini_batches
+    )
+
+    compile_mode = None
+    if cfg.compile.compile:
+        compile_mode = cfg.compile.compile_mode
+        if compile_mode in ("", None):
+            if cfg.compile.cudagraphs:
+                compile_mode = "default"
+            else:
+                compile_mode = "reduce-overhead"
+
+    # Create models (reusing PPO model architecture)
+    actor, critic = make_ppo_models(cfg.env.env_name, device=device)
+
+    # Create collector
+    collector = SyncDataCollector(
+        create_env_fn=make_env(cfg.env.env_name, device),
+        policy=actor,
+        frames_per_batch=cfg.collector.frames_per_batch,
+        total_frames=cfg.collector.total_frames,
+        device=device,
+        max_frames_per_traj=-1,
+        compile_policy={"mode": compile_mode, "warmup": 1} if compile_mode else False,
+        cudagraph_policy={"warmup": 10} if cfg.compile.cudagraphs else False,
+    )
+
+    # Create data buffer
+    sampler = SamplerWithoutReplacement()
+    data_buffer = TensorDictReplayBuffer(
+        storage=LazyTensorStorage(
+            cfg.collector.frames_per_batch,
+            compilable=cfg.compile.compile,
+            device=device,
+        ),
+        sampler=sampler,
+        batch_size=cfg.loss.mini_batch_size,
+        compilable=cfg.compile.compile,
+    )
+
+    # Create loss and adv modules
+    adv_module = GAE(
+        gamma=cfg.loss.gamma,
+        lmbda=cfg.loss.gae_lambda,
+        value_network=critic,
+        average_gae=False,
+        device=device,
+        vectorized=not cfg.compile.compile,
+    )
+
+    loss_module = SPOLoss(
+        actor_network=actor,
+        critic_network=critic,
+        epsilon=cfg.loss.epsilon,
+        loss_critic_type=cfg.loss.loss_critic_type,
+        entropy_coef=cfg.loss.entropy_coef,
+        critic_coef=cfg.loss.critic_coef,
+        normalize_advantage=True,
+    )
+
+    # Create optimizers
+    actor_optim = torch.optim.Adam(
+        actor.parameters(), lr=torch.tensor(cfg.optim.lr, device=device), eps=1e-5
+    )
+    critic_optim = torch.optim.Adam(
+        critic.parameters(), lr=torch.tensor(cfg.optim.lr, device=device), eps=1e-5
+    )
+    optim = group_optimizers(actor_optim, critic_optim)
+    del actor_optim, critic_optim
+
+    # Create logger
+    logger = None
+    if cfg.logger.backend:
+        exp_name = generate_exp_name("SPO", f"{cfg.logger.exp_name}_{cfg.env.env_name}")
+        logger = get_logger(
+            cfg.logger.backend,
+            logger_name="spo",
+            experiment_name=exp_name,
+            wandb_kwargs={
+                "config": dict(cfg),
+                "project": cfg.logger.project_name,
+                "group": cfg.logger.group_name,
+            },
+        )
+        logger_video = cfg.logger.video
+    else:
+        logger_video = False
+
+    # Create test environment
+    test_env = make_env(cfg.env.env_name, device, from_pixels=logger_video)
+    if logger_video:
+        test_env = test_env.append_transform(
+            VideoRecorder(logger, tag="rendering/test", in_keys=["pixels"])
+        )
+    test_env.eval()
+
+    def update(batch, num_network_updates):
+        optim.zero_grad(set_to_none=True)
+        # Linearly decrease the learning rate
+        alpha = torch.ones((), device=device)
+        if cfg_optim_anneal_lr:
+            alpha = 1 - (num_network_updates / total_network_updates)
+            for group in optim.param_groups:
+                group["lr"] = cfg_optim_lr * alpha
+        num_network_updates = num_network_updates + 1
+
+        # Forward pass SPO loss
+        loss = loss_module(batch)
+        critic_loss = loss["loss_critic"]
+        actor_loss = loss["loss_objective"] + loss["loss_entropy"]
+        total_loss = critic_loss + actor_loss
+
+        # Backward pass
+        total_loss.backward()
+
+        # Update the networks
+        optim.step()
+        return loss.detach().set("alpha", alpha), num_network_updates
+
+    if cfg.compile.compile:
+        update = compile_with_warmup(update, mode=compile_mode, warmup=1)
+        adv_module = compile_with_warmup(adv_module, mode=compile_mode, warmup=1)
+
+    if cfg.compile.cudagraphs:
+        warnings.warn(
+            "CudaGraphModule is experimental and may lead to silently wrong results. Use with caution.",
+            category=UserWarning,
+        )
+        update = CudaGraphModule(update, in_keys=[], out_keys=[], warmup=5)
+        adv_module = CudaGraphModule(adv_module)
+
+    # Main loop
+    collected_frames = 0
+    num_network_updates = torch.zeros((), dtype=torch.int64, device=device)
+    pbar = tqdm.tqdm(total=cfg.collector.total_frames)
+
+    # extract cfg variables
+    cfg_loss_spo_epochs = cfg.loss.spo_epochs
+    cfg_optim_anneal_lr = cfg.optim.anneal_lr
+    cfg_optim_lr = torch.tensor(cfg.optim.lr, device=device)
+    cfg_logger_test_interval = cfg.logger.test_interval
+    cfg_logger_num_test_episodes = cfg.logger.num_test_episodes
+    losses = TensorDict(batch_size=[cfg_loss_spo_epochs, num_mini_batches])
+
+    collector_iter = iter(collector)
+    total_iter = len(collector)
+    for i in range(total_iter):
+        timeit.printevery(1000, total_iter, erase=True)
+
+        with timeit("collecting"):
+            data = next(collector_iter)
+
+        metrics_to_log = {}
+        frames_in_batch = data.numel()
+        collected_frames += frames_in_batch
+        pbar.update(frames_in_batch)
+
+        # Get training rewards and episode lengths
+        episode_rewards = data["next", "episode_reward"][data["next", "done"]]
+        if len(episode_rewards) > 0:
+            episode_length = data["next", "step_count"][data["next", "done"]]
+            metrics_to_log.update(
+                {
+                    "train/reward": episode_rewards.mean().item(),
+                    "train/episode_length": episode_length.sum().item()
+                    / len(episode_length),
+                }
+            )
+
+        with timeit("training"):
+            for j in range(cfg_loss_spo_epochs):
+
+                # Compute GAE
+                with torch.no_grad(), timeit("adv"):
+                    torch.compiler.cudagraph_mark_step_begin()
+                    data = adv_module(data)
+                    if compile_mode:
+                        data = data.clone()
+
+                with timeit("rb - extend"):
+                    # Update the data buffer
+                    data_reshape = data.reshape(-1)
+                    data_buffer.extend(data_reshape)
+
+                for k, batch in enumerate(data_buffer):
+                    with timeit("update"):
+                        torch.compiler.cudagraph_mark_step_begin()
+                        loss, num_network_updates = update(
+                            batch, num_network_updates=num_network_updates
+                        )
+                        loss = loss.clone()
+                    num_network_updates = num_network_updates.clone()
+                    losses[j, k] = loss.select(
+                        "loss_critic", "loss_entropy", "loss_objective"
+                    )
+
+        # Get training losses and times
+        losses_mean = losses.apply(lambda x: x.float().mean(), batch_size=[])
+        for key, value in losses_mean.items():
+            metrics_to_log.update({f"train/{key}": value.item()})
+        metrics_to_log.update(
+            {
+                "train/lr": loss["alpha"] * cfg_optim_lr,
+                "train/ratio_deviation": loss["ratio_deviation"].item(),
+            }
+        )
+
+        # Get test rewards
+        with torch.no_grad(), set_exploration_type(
+            ExplorationType.DETERMINISTIC
+        ), timeit("eval"):
+            if ((i - 1) * frames_in_batch) // cfg_logger_test_interval < (
+                i * frames_in_batch
+            ) // cfg_logger_test_interval:
+                actor.eval()
+                test_rewards = eval_model(
+                    actor, test_env, num_episodes=cfg_logger_num_test_episodes
+                )
+                metrics_to_log.update(
+                    {
+                        "eval/reward": test_rewards.mean(),
+                    }
+                )
+                actor.train()
+
+        if logger:
+            metrics_to_log.update(timeit.todict(prefix="time"))
+            metrics_to_log["time/speed"] = pbar.format_dict["rate"]
+            for key, value in metrics_to_log.items():
+                logger.log_scalar(key, value, collected_frames)
+
+        collector.update_policy_weights_()
+
+    collector.shutdown()
+    if not test_env.is_closed:
+        test_env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/sota-implementations/spo/utils_mujoco.py
+++ b/sota-implementations/spo/utils_mujoco.py
@@ -1,0 +1,152 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import torch.nn
+import torch.optim
+
+from tensordict.nn import AddStateIndependentNormalScale, TensorDictModule
+from torchrl.envs import (
+    ClipTransform,
+    DoubleToFloat,
+    ExplorationType,
+    RewardSum,
+    StepCounter,
+    TransformedEnv,
+    VecNorm,
+)
+from torchrl.envs.libs.gym import GymEnv
+from torchrl.modules import MLP, ProbabilisticActor, TanhNormal, ValueOperator
+from torchrl.record import VideoRecorder
+
+
+# ====================================================================
+# Environment utils
+# --------------------------------------------------------------------
+
+
+def make_env(env_name="HalfCheetah-v4", device="cpu", from_pixels: bool = False):
+    env = GymEnv(env_name, device=device, from_pixels=from_pixels, pixels_only=False)
+    env = TransformedEnv(env)
+    env.append_transform(VecNorm(in_keys=["observation"], decay=0.99999, eps=1e-2))
+    env.append_transform(ClipTransform(in_keys=["observation"], low=-10, high=10))
+    env.append_transform(RewardSum())
+    env.append_transform(StepCounter())
+    env.append_transform(DoubleToFloat(in_keys=["observation"]))
+    return env
+
+
+# ====================================================================
+# Model utils
+# --------------------------------------------------------------------
+
+
+def make_ppo_models_state(proof_environment, device):
+
+    # Define input shape
+    input_shape = proof_environment.observation_spec["observation"].shape
+
+    # Define policy output distribution class
+    num_outputs = proof_environment.action_spec_unbatched.shape[-1]
+    distribution_class = TanhNormal
+    distribution_kwargs = {
+        "low": proof_environment.action_spec_unbatched.space.low.to(device),
+        "high": proof_environment.action_spec_unbatched.space.high.to(device),
+        "tanh_loc": False,
+    }
+
+    # Define policy architecture
+    policy_mlp = MLP(
+        in_features=input_shape[-1],
+        activation_class=torch.nn.Tanh,
+        out_features=num_outputs,  # predict only loc
+        num_cells=[64, 64],
+        device=device,
+    )
+
+    # Initialize policy weights
+    for layer in policy_mlp.modules():
+        if isinstance(layer, torch.nn.Linear):
+            torch.nn.init.orthogonal_(layer.weight, 1.0)
+            layer.bias.data.zero_()
+
+    # Add state-independent normal scale
+    policy_mlp = torch.nn.Sequential(
+        policy_mlp,
+        AddStateIndependentNormalScale(
+            proof_environment.action_spec_unbatched.shape[-1], scale_lb=1e-8
+        ).to(device),
+    )
+
+    # Add probabilistic sampling of the actions
+    policy_module = ProbabilisticActor(
+        TensorDictModule(
+            module=policy_mlp,
+            in_keys=["observation"],
+            out_keys=["loc", "scale"],
+        ),
+        in_keys=["loc", "scale"],
+        spec=proof_environment.full_action_spec_unbatched.to(device),
+        distribution_class=distribution_class,
+        distribution_kwargs=distribution_kwargs,
+        return_log_prob=True,
+        default_interaction_type=ExplorationType.RANDOM,
+    )
+
+    # Define value architecture
+    value_mlp = MLP(
+        in_features=input_shape[-1],
+        activation_class=torch.nn.Tanh,
+        out_features=1,
+        num_cells=[64, 64],
+        device=device,
+    )
+
+    # Initialize value weights
+    for layer in value_mlp.modules():
+        if isinstance(layer, torch.nn.Linear):
+            torch.nn.init.orthogonal_(layer.weight, 0.01)
+            layer.bias.data.zero_()
+
+    # Define value module
+    value_module = ValueOperator(
+        value_mlp,
+        in_keys=["observation"],
+    )
+
+    return policy_module, value_module
+
+
+def make_ppo_models(env_name, device):
+    proof_environment = make_env(env_name, device=device)
+    actor, critic = make_ppo_models_state(proof_environment, device=device)
+    return actor, critic
+
+
+# ====================================================================
+# Evaluation utils
+# --------------------------------------------------------------------
+
+
+def dump_video(module):
+    if isinstance(module, VideoRecorder):
+        module.dump()
+
+
+def eval_model(actor, test_env, num_episodes=3):
+    test_rewards = []
+    for _ in range(num_episodes):
+        td_test = test_env.rollout(
+            policy=actor,
+            auto_reset=True,
+            auto_cast_to_device=True,
+            break_when_any_done=True,
+            max_steps=10_000_000,
+        )
+        reward = td_test["next", "episode_reward"][td_test["next", "done"]]
+        test_rewards.append(reward.cpu())
+        test_env.apply(dump_video)
+    del td_test
+    return torch.cat(test_rewards, 0).mean()

--- a/test/test_objectives.py
+++ b/test/test_objectives.py
@@ -112,6 +112,7 @@ from torchrl.objectives import (
     PPOLoss,
     QMixerLoss,
     SACLoss,
+    SPOLoss,
     TD3BCLoss,
     TD3Loss,
 )
@@ -9249,14 +9250,18 @@ class TestPPO(LossModuleTestBase):
 
         return td
 
-    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss, SPOLoss)
+    )
     def test_reset_parameters_recursive(self, loss_class):
         actor = self._create_mock_actor()
         value = self._create_mock_value()
         loss_fn = loss_class(actor, value)
         self.reset_parameters_recursive_test(loss_fn)
 
-    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss, SPOLoss)
+    )
     @pytest.mark.parametrize("gradient_mode", (True, False))
     @pytest.mark.parametrize("advantage", ("gae", "vtrace", "td", "td_lambda", None))
     @pytest.mark.parametrize("device", get_default_devices())
@@ -9366,7 +9371,9 @@ class TestPPO(LossModuleTestBase):
         assert counter == 2
         actor.zero_grad()
 
-    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss, SPOLoss)
+    )
     @pytest.mark.parametrize("gradient_mode", (True, False))
     @pytest.mark.parametrize("advantage", ("gae", "vtrace", "td", "td_lambda", None))
     @pytest.mark.parametrize("device", get_default_devices())
@@ -9460,7 +9467,9 @@ class TestPPO(LossModuleTestBase):
         assert counter == 2
         actor.zero_grad()
 
-    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss, SPOLoss)
+    )
     @pytest.mark.parametrize("gradient_mode", (True,))
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("composite_action_dist", [True, False])
@@ -9488,7 +9497,9 @@ class TestPPO(LossModuleTestBase):
         )
         loss_fn2.load_state_dict(sd)
 
-    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss, SPOLoss)
+    )
     @pytest.mark.parametrize("advantage", ("gae", "vtrace", "td", "td_lambda", None))
     @pytest.mark.parametrize("device", get_default_devices())
     @pytest.mark.parametrize("composite_action_dist", [True, False])
@@ -9579,7 +9590,9 @@ class TestPPO(LossModuleTestBase):
         actor.zero_grad()
         assert counter == 4
 
-    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss, SPOLoss)
+    )
     @pytest.mark.parametrize(
         "advantage",
         (
@@ -9704,7 +9717,9 @@ class TestPPO(LossModuleTestBase):
     @pytest.mark.skipif(
         not _has_functorch, reason=f"functorch not found, {FUNCTORCH_ERR}"
     )
-    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss, SPOLoss)
+    )
     @pytest.mark.parametrize("gradient_mode", (True, False))
     @pytest.mark.parametrize("advantage", ("gae", "vtrace", "td", "td_lambda", None))
     @pytest.mark.parametrize("device", get_default_devices())
@@ -9809,7 +9824,9 @@ class TestPPO(LossModuleTestBase):
         for param in params.values(True, True):
             param.grad = None
 
-    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss, SPOLoss)
+    )
     @pytest.mark.parametrize(
         "td_est",
         [
@@ -9861,7 +9878,9 @@ class TestPPO(LossModuleTestBase):
         }
         self.set_advantage_keys_through_loss_test(loss_fn, td_est, key_mapping)
 
-    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss, SPOLoss)
+    )
     @pytest.mark.parametrize("advantage", ("gae", "vtrace", "td", "td_lambda", None))
     @pytest.mark.parametrize("td_est", list(ValueEstimators) + [None])
     def test_ppo_tensordict_keys_run(self, loss_class, advantage, td_est):
@@ -9966,7 +9985,9 @@ class TestPPO(LossModuleTestBase):
         assert counter == 2
         actor.zero_grad()
 
-    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss, SPOLoss)
+    )
     @pytest.mark.parametrize("action_key", ["action", "action2"])
     @pytest.mark.parametrize("sample_log_prob_key", ["samplelogprob", "samplelogprob2"])
     @pytest.mark.parametrize("observation_key", ["observation", "observation2"])
@@ -10067,7 +10088,9 @@ class TestPPO(LossModuleTestBase):
         assert loss_obj == loss_val_td.get("loss_objective")
         assert loss_crit == loss_val_td.get("loss_critic")
 
-    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss, SPOLoss)
+    )
     @pytest.mark.parametrize("reduction", [None, "none", "mean", "sum"])
     @pytest.mark.parametrize("composite_action_dist", [True, False])
     def test_ppo_reduction(self, reduction, loss_class, composite_action_dist):
@@ -10113,7 +10136,9 @@ class TestPPO(LossModuleTestBase):
                 assert loss[key].shape == torch.Size([])
 
     @pytest.mark.parametrize("device", get_default_devices())
-    @pytest.mark.parametrize("loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss))
+    @pytest.mark.parametrize(
+        "loss_class", (PPOLoss, ClipPPOLoss, KLPENPPOLoss, SPOLoss)
+    )
     @pytest.mark.parametrize("clip_value", [True, False, None, 0.5, torch.tensor(0.5)])
     @pytest.mark.parametrize("composite_action_dist", [True, False])
     def test_ppo_value_clipping(

--- a/torchrl/objectives/__init__.py
+++ b/torchrl/objectives/__init__.py
@@ -22,6 +22,7 @@ from torchrl.objectives.ppo import ClipPPOLoss, KLPENPPOLoss, PPOLoss
 from torchrl.objectives.redq import REDQLoss
 from torchrl.objectives.reinforce import ReinforceLoss
 from torchrl.objectives.sac import DiscreteSACLoss, SACLoss
+from torchrl.objectives.spo import SPOLoss
 from torchrl.objectives.td3 import TD3Loss
 from torchrl.objectives.td3_bc import TD3BCLoss
 from torchrl.objectives.utils import (
@@ -64,6 +65,7 @@ __all__ = [
     "ReinforceLoss",
     "SACLoss",
     "SoftUpdate",
+    "SPOLoss",
     "TD3BCLoss",
     "TD3Loss",
     "TargetNetUpdater",

--- a/torchrl/objectives/spo.py
+++ b/torchrl/objectives/spo.py
@@ -1,0 +1,271 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import warnings
+from collections.abc import Mapping
+
+import torch
+from tensordict import is_tensor_collection, TensorDict, TensorDictBase
+
+from tensordict.nn import dispatch, ProbabilisticTensorDictSequential, TensorDictModule
+from tensordict.utils import NestedKey
+
+from torchrl._utils import _standardize
+from torchrl.objectives.ppo import PPOLoss
+from torchrl.objectives.utils import _reduce, _sum_td_features
+
+
+class SPOLoss(PPOLoss):
+    """Simple Policy Optimization (SPO) loss.
+
+    SPO is a policy gradient algorithm that modifies PPO's clipping objective
+    with a quadratic penalty term to better constrain the probability ratio
+    within the trust region. The key insight is replacing PPO's min-clip
+    operation with a soft quadratic penalty that provides stronger theoretical
+    guarantees while maintaining computational simplicity.
+
+    The SPO policy loss is computed as:
+        loss = -mean(r(θ) * A - |A| / (2ε) * (r(θ) - 1)²)
+
+    where r(θ) = π_θ(a|s) / π_θ_old(a|s) is the probability ratio,
+    A is the advantage estimate, and ε is the trust region parameter.
+
+    For more details, refer to: "Simple Policy Optimization",
+    https://arxiv.org/abs/2401.16025
+
+    Args:
+        actor_network (ProbabilisticTensorDictSequential): policy operator.
+        critic_network (ValueOperator): value operator.
+
+    Keyword Args:
+        epsilon (float, optional): trust region parameter that controls the
+            strength of the quadratic penalty. Corresponds to the clip
+            parameter in PPO. Defaults to ``0.2``.
+        entropy_bonus (bool, optional): if ``True``, an entropy bonus will be added to the
+            loss to favour exploratory policies.
+        samples_mc_entropy (int, optional): if the distribution retrieved from the policy
+            operator does not have a closed form formula for the entropy, a Monte-Carlo
+            estimate will be used. ``samples_mc_entropy`` will control how many
+            samples will be used to compute this estimate. Defaults to ``1``.
+        entropy_coeff (float | Mapping[NestedKey, float], optional): entropy multiplier
+            when computing the total loss. Defaults to ``0.01``.
+        critic_coeff (float, optional): critic loss multiplier when computing the total
+            loss. Defaults to ``1.0``. Set ``critic_coeff`` to ``None`` to exclude the value
+            loss from the forward outputs.
+        loss_critic_type (str, optional): loss function for the value discrepancy.
+            Can be one of "l1", "l2" or "smooth_l1". Defaults to ``"smooth_l1"``.
+        normalize_advantage (bool, optional): if ``True``, the advantage will be normalized
+            before being used. Defaults to ``False``.
+        normalize_advantage_exclude_dims (tuple[int], optional): dimensions to exclude from
+            the advantage standardization. Defaults to ().
+        separate_losses (bool, optional): if ``True``, shared parameters between
+            policy and critic will only be trained on the policy loss.
+            Defaults to ``False``.
+        functional (bool, optional): whether modules should be functionalized.
+            Defaults to ``True``.
+        reduction (str, optional): Specifies the reduction to apply to the output:
+            ``"none"`` | ``"mean"`` | ``"sum"``. Defaults to ``"mean"``.
+        clip_value (float, optional): If provided, it will be used to compute a clipped
+            version of the value prediction. Defaults to ``None``.
+        device (torch.device, optional): device of the buffers. Defaults to ``None``.
+
+    Examples:
+        >>> import torch
+        >>> from torch import nn
+        >>> from torchrl.data.tensor_specs import Bounded
+        >>> from torchrl.modules.distributions import NormalParamExtractor, TanhNormal
+        >>> from torchrl.modules.tensordict_module.actors import ProbabilisticActor, ValueOperator
+        >>> from torchrl.modules.tensordict_module.common import SafeModule
+        >>> from torchrl.objectives.spo import SPOLoss
+        >>> from tensordict import TensorDict
+        >>> n_act, n_obs = 4, 3
+        >>> spec = Bounded(-torch.ones(n_act), torch.ones(n_act), (n_act,))
+        >>> base_layer = nn.Linear(n_obs, 5)
+        >>> net = nn.Sequential(base_layer, nn.Linear(5, 2 * n_act), NormalParamExtractor())
+        >>> module = SafeModule(net, in_keys=["observation"], out_keys=["loc", "scale"])
+        >>> actor = ProbabilisticActor(
+        ...     module=module,
+        ...     distribution_class=TanhNormal,
+        ...     in_keys=["loc", "scale"],
+        ...     spec=spec)
+        >>> module = nn.Sequential(base_layer, nn.Linear(5, 1))
+        >>> value = ValueOperator(
+        ...     module=module,
+        ...     in_keys=["observation"])
+        >>> loss = SPOLoss(actor, value)
+        >>> batch = [2, ]
+        >>> action = spec.rand(batch)
+        >>> data = TensorDict({"observation": torch.randn(*batch, n_obs),
+        ...         "action": action,
+        ...         "action_log_prob": torch.randn_like(action[..., 1]),
+        ...         ("next", "done"): torch.zeros(*batch, 1, dtype=torch.bool),
+        ...         ("next", "terminated"): torch.zeros(*batch, 1, dtype=torch.bool),
+        ...         ("next", "reward"): torch.randn(*batch, 1),
+        ...         ("next", "observation"): torch.randn(*batch, n_obs),
+        ...     }, batch)
+        >>> loss(data)
+        TensorDict(
+            fields={
+                entropy: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False),
+                loss_critic: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False),
+                loss_entropy: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False),
+                loss_objective: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False),
+                ratio_deviation: Tensor(shape=torch.Size([]), device=cpu, dtype=torch.float32, is_shared=False)},
+            batch_size=torch.Size([]),
+            device=None,
+            is_shared=False)
+    """
+
+    def __init__(
+        self,
+        actor_network: ProbabilisticTensorDictSequential | None = None,
+        critic_network: TensorDictModule | None = None,
+        *,
+        epsilon: float = 0.2,
+        entropy_bonus: bool = True,
+        samples_mc_entropy: int = 1,
+        entropy_coeff: float | Mapping[NestedKey, float] | None = None,
+        critic_coeff: float | None = None,
+        loss_critic_type: str = "smooth_l1",
+        normalize_advantage: bool = False,
+        normalize_advantage_exclude_dims: tuple[int] = (),
+        gamma: float | None = None,
+        separate_losses: bool = False,
+        reduction: str | None = None,
+        clip_value: float | None = None,
+        device: torch.device | None = None,
+        **kwargs,
+    ):
+        super().__init__(
+            actor_network,
+            critic_network,
+            entropy_bonus=entropy_bonus,
+            samples_mc_entropy=samples_mc_entropy,
+            entropy_coeff=entropy_coeff,
+            critic_coeff=critic_coeff,
+            loss_critic_type=loss_critic_type,
+            normalize_advantage=normalize_advantage,
+            normalize_advantage_exclude_dims=normalize_advantage_exclude_dims,
+            gamma=gamma,
+            separate_losses=separate_losses,
+            reduction=reduction,
+            clip_value=clip_value,
+            device=device,
+            **kwargs,
+        )
+        if device is None:
+            try:
+                device = next(self.parameters()).device
+            except (AttributeError, StopIteration):
+                device = getattr(
+                    torch, "get_default_device", lambda: torch.device("cpu")
+                )()
+        self.register_buffer("epsilon", torch.tensor(epsilon, device=device))
+
+    @property
+    def out_keys(self):
+        if self._out_keys is None:
+            keys = ["loss_objective", "ratio_deviation"]
+            if self.entropy_bonus:
+                keys.extend(["entropy", "loss_entropy"])
+            if self.loss_critic:
+                keys.append("loss_critic")
+            if self.clip_value:
+                keys.append("value_clip_fraction")
+            self._out_keys = keys
+        return self._out_keys
+
+    @out_keys.setter
+    def out_keys(self, values):
+        self._out_keys = values
+
+    @dispatch
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+        tensordict = tensordict.clone(False)
+        advantage = tensordict.get(
+            self.tensor_keys.advantage, None, as_padded_tensor=True
+        )
+        if advantage is None:
+            if self.critic_network is None:
+                raise RuntimeError(
+                    "Critic network is not specified, cannot compute advantage within forward."
+                )
+            self.value_estimator(
+                tensordict,
+                params=self._cached_critic_network_params_detached,
+                target_params=self.target_critic_network_params,
+            )
+            advantage = tensordict.get(self.tensor_keys.advantage)
+        if self.normalize_advantage and advantage.numel() > 1:
+            if advantage.numel() > tensordict.batch_size.numel() and not len(
+                self.normalize_advantage_exclude_dims
+            ):
+                warnings.warn(
+                    "You requested advantage normalization and the advantage key has more dimensions"
+                    " than the tensordict batch. Make sure to pass `normalize_advantage_exclude_dims` "
+                    "if you want to keep any dimension independent while computing normalization statistics. "
+                    "If you are working in multi-agent/multi-objective settings this is highly suggested."
+                )
+            advantage = _standardize(advantage, self.normalize_advantage_exclude_dims)
+
+        log_weight, dist, kl_approx = self._log_weight(
+            tensordict, adv_shape=advantage.shape[:-1]
+        )
+
+        # Compute the probability ratio
+        ratio = log_weight.exp()
+
+        # SPO loss: r(θ) * A - |A| / (2ε) * (r(θ) - 1)²
+        # The quadratic penalty term constrains the ratio within the trust region
+        ratio_deviation = ratio - 1
+        quadratic_penalty = (advantage.abs() / (2 * self.epsilon)) * (
+            ratio_deviation**2
+        )
+        neg_loss = ratio * advantage - quadratic_penalty
+
+        # Log ratio deviation for monitoring (useful for debugging trust region violations)
+        with torch.no_grad():
+            mean_ratio_deviation = ratio_deviation.abs().mean()
+
+        td_out = TensorDict({"loss_objective": -neg_loss})
+        td_out.set("ratio_deviation", mean_ratio_deviation)
+        td_out.set("kl_approx", kl_approx.detach().mean())  # for logging
+
+        if self.entropy_bonus:
+            entropy = self._get_entropy(dist, adv_shape=advantage.shape[:-1])
+            if is_tensor_collection(entropy):
+                # Reports the entropy of each action head.
+                td_out.set("composite_entropy", entropy.detach())
+                td_out.set(
+                    "entropy", _sum_td_features(entropy).detach().mean()
+                )  # for logging
+            else:
+                td_out.set("entropy", entropy.detach().mean())  # for logging
+            td_out.set("loss_entropy", self._weighted_loss_entropy(entropy))
+        if self._has_critic:
+            loss_critic, value_clip_fraction, explained_variance = self.loss_critic(
+                tensordict
+            )
+            td_out.set("loss_critic", loss_critic)
+            if value_clip_fraction is not None:
+                td_out.set("value_clip_fraction", value_clip_fraction)
+            if explained_variance is not None:
+                td_out.set("explained_variance", explained_variance)
+
+        td_out = td_out.named_apply(
+            lambda name, value: _reduce(value, reduction=self.reduction).squeeze(-1)
+            if name.startswith("loss_")
+            else value,
+        )
+        self._clear_weakrefs(
+            tensordict,
+            td_out,
+            "actor_network_params",
+            "critic_network_params",
+            "target_actor_network_params",
+            "target_critic_network_params",
+        )
+        return td_out


### PR DESCRIPTION
## Summary

Implements the Simple Policy Optimization (SPO) algorithm from ["Simple Policy Optimization"](https://arxiv.org/abs/2401.16025) (Lu et al., 2024).

SPO modifies PPO's clipping objective with a quadratic penalty term to better constrain the probability ratio within the trust region, achieving stronger theoretical guarantees while maintaining computational simplicity.

### Key Changes

- **New `SPOLoss` module** (`torchrl/objectives/spo.py`): Inherits from `PPOLoss` and implements the SPO policy loss formula:
  ```
  L_p = -(r(θ) * A - |A|/(2ε) * (r(θ) - 1)²)
  ```
  
- **SOTA Implementation** (`sota-implementations/spo/`): Complete MuJoCo training script following paper hyperparameters

- **Test Integration**: Added `SPOLoss` to existing PPO test parametrizations

### Paper Hyperparameters (MuJoCo)

| Parameter | Value |
|-----------|-------|
| epsilon (ε) | 0.2 |
| critic_coeff | 0.5 |
| entropy_coeff | 0.0 |
| GAE lambda | 0.95 |
| Learning rate | 3e-4 |

### Usage Example

```python
from torchrl.objectives import SPOLoss

loss_module = SPOLoss(
    actor_network=actor,
    critic_network=critic,
    epsilon=0.2,
    normalize_advantage=True,
)

# Forward pass returns loss_objective, loss_critic, loss_entropy, ratio_deviation
loss = loss_module(data)
```

## Test plan

- [x] Manual verification of `SPOLoss` forward pass
- [x] Import verification successful
- [x] Pre-commit linting passed (ufmt, flake8, pydocstyle)
- [ ] Full test suite (requires transformers library in test environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)