### PR TITLE
[Feature] Add CTRL (Cross-Trajectory Representation Learning) Implementation

### DIFF
--- a/sota-implementations/ctrl/README.md
+++ b/sota-implementations/ctrl/README.md
@@ -1,0 +1,134 @@
+# CTRL: Cross-Trajectory Representation Learning
+
+This implementation reproduces the CTRL algorithm from the paper:
+
+**"Cross-Trajectory Representation Learning for Zero-Shot Generalization in RL"**
+Bogdan Mazoure, Ahmed M. Ahmed, Patrick MacAlpine, R. Devon Hjelm, Andrey Kolobov
+ICLR 2022
+
+Paper: https://arxiv.org/abs/2106.02193
+
+## Overview
+
+CTRL is a self-supervised representation learning method for RL that improves zero-shot generalization. The key insight is that a good encoder for generalization should map behaviorally similar observations to similar representations, regardless of the specific task or level.
+
+### Key Components
+
+1. **Prototype-based Contrastive Learning**: Uses learnable prototype vectors and the Sinkhorn algorithm for soft cluster assignments
+2. **MYOW (Make Your Own Winners) Loss**: Encourages consistency between representations that share nearby prototypes
+3. **Integration with PPO**: CTRL serves as an auxiliary loss that trains the encoder alongside the standard PPO objective
+
+## Installation
+
+```bash
+# Install TorchRL
+pip install torchrl
+
+# Install Procgen (required for this implementation)
+pip install procgen
+
+# Install additional dependencies
+pip install hydra-core wandb tqdm
+```
+
+## Usage
+
+### Basic Training
+
+```bash
+# Train on CoinRun (default)
+python ctrl_procgen.py
+
+# Train on a different Procgen game
+python ctrl_procgen.py env.env_name=procgen:procgen-starpilot-v0
+
+# Train with more levels (harder generalization)
+python ctrl_procgen.py env.num_levels=500
+```
+
+### Configuration Options
+
+Key parameters can be modified via command line:
+
+```bash
+# Adjust CTRL hyperparameters
+python ctrl_procgen.py ctrl.num_prototypes=256 ctrl.temperature=0.05
+
+# Adjust training
+python ctrl_procgen.py collector.total_frames=50_000_000 loss.ppo_epochs=4
+
+# Use hard difficulty
+python ctrl_procgen.py env.distribution_mode=hard
+
+# Enable torch.compile for faster training
+python ctrl_procgen.py compile.compile=true
+```
+
+### Logging
+
+By default, results are logged to Weights & Biases. To change:
+
+```bash
+# Use TensorBoard instead
+python ctrl_procgen.py logger.backend=tensorboard
+
+# Disable logging
+python ctrl_procgen.py logger.backend=""
+```
+
+## Procgen Environments
+
+CTRL was designed for the Procgen benchmark which tests generalization. Available games:
+
+- `procgen-coinrun-v0` (default)
+- `procgen-starpilot-v0`
+- `procgen-caveflyer-v0`
+- `procgen-dodgeball-v0`
+- `procgen-fruitbot-v0`
+- `procgen-chaser-v0`
+- `procgen-miner-v0`
+- `procgen-jumper-v0`
+- `procgen-leaper-v0`
+- `procgen-maze-v0`
+- `procgen-bigfish-v0`
+- `procgen-heist-v0`
+- `procgen-climber-v0`
+- `procgen-plunder-v0`
+- `procgen-ninja-v0`
+- `procgen-bossfight-v0`
+
+## Expected Results
+
+On Procgen with 200 training levels (easy mode), CTRL should show improved generalization performance compared to vanilla PPO, particularly on test levels not seen during training.
+
+## Algorithm Details
+
+### CTRL Loss
+
+The CTRL loss combines two components:
+
+1. **Prototype Loss**: Cross-entropy between Sinkhorn-computed soft assignments and prediction head outputs
+2. **MYOW Loss**: Cosine similarity loss between representations that share nearby prototypes
+
+```
+L_CTRL = L_proto + myow_coeff * L_myow
+```
+
+### Training Loop
+
+1. Collect trajectories using PPO policy
+2. Compute PPO losses (policy, value, entropy)
+3. Compute CTRL losses on encoder representations
+4. Update policy/value networks with PPO gradients
+5. Update encoder/prototypes with CTRL gradients
+
+## Citation
+
+```bibtex
+@inproceedings{mazoure2022cross,
+  title={Cross-Trajectory Representation Learning for Zero-Shot Generalization in {RL}},
+  author={Mazoure, Bogdan and Ahmed, Ahmed M and MacAlpine, Patrick and Hjelm, R Devon and Kolobov, Andrey},
+  booktitle={International Conference on Learning Representations},
+  year={2022}
+}
+```

--- a/sota-implementations/ctrl/config.yaml
+++ b/sota-implementations/ctrl/config.yaml
@@ -1,0 +1,67 @@
+# CTRL + PPO Configuration for Procgen
+# Reference: "Cross-Trajectory Representation Learning for Zero-Shot Generalization in RL"
+
+# Environment settings
+env:
+  env_name: procgen:procgen-coinrun-v0
+  num_envs: 64
+  num_levels: 200  # Number of training levels (0 = unlimited)
+  distribution_mode: easy  # easy, hard, extreme
+  backend: gymnasium
+
+# Model settings
+model:
+  embedding_dim: 256  # Encoder output dimension
+
+# Data collection
+collector:
+  total_frames: 25_000_000
+  frames_per_batch: 2048
+
+# Loss settings
+loss:
+  mini_batch_size: 512
+  ppo_epochs: 3
+  clip_epsilon: 0.2
+  gamma: 0.999
+  gae_lambda: 0.95
+  entropy_coeff: 0.01
+  critic_coeff: 0.5
+  loss_critic_type: l2
+
+# CTRL settings
+ctrl:
+  projection_dim: 128
+  num_prototypes: 512
+  sinkhorn_iters: 3
+  temperature: 0.1
+  window_len: 4
+  myow_k: 5
+  myow_coeff: 1.0
+  ctrl_coeff: 1.0  # Weight for CTRL loss in total loss
+
+# Optimizer settings
+optim:
+  lr: 5e-4
+  ctrl_lr: 1e-4
+  weight_decay: 0.0
+  eps: 1e-5
+  max_grad_norm: 0.5
+  anneal_lr: true
+  device: ""  # Empty string means auto-detect
+
+# Logging
+logger:
+  backend: wandb  # wandb, tensorboard, or ""
+  project_name: ctrl_procgen
+  group_name: null
+  exp_name: ctrl_ppo
+  test_interval: 50_000
+  num_test_episodes: 10
+  video: false
+
+# Compilation settings
+compile:
+  compile: false
+  compile_mode: null
+  cudagraphs: false

--- a/sota-implementations/ctrl/ctrl_procgen.py
+++ b/sota-implementations/ctrl/ctrl_procgen.py
@@ -1,0 +1,364 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+This script implements Cross-Trajectory Representation Learning (CTRL)
+combined with PPO for the Procgen benchmark.
+
+CTRL is a self-supervised representation learning method that improves
+zero-shot generalization by training encoders to recognize behavioral
+similarity across trajectories.
+
+Reference: "Cross-Trajectory Representation Learning for Zero-Shot Generalization in RL"
+https://arxiv.org/abs/2106.02193
+"""
+from __future__ import annotations
+
+import warnings
+
+import hydra
+
+
+@hydra.main(config_path="", config_name="config", version_base="1.1")
+def main(cfg: DictConfig):  # noqa: F821
+
+    import torch
+    import torch.optim
+    import tqdm
+
+    from tensordict import TensorDict
+    from tensordict.nn import CudaGraphModule
+
+    from torchrl._utils import timeit
+    from torchrl.collectors import SyncDataCollector
+    from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
+    from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
+    from torchrl.envs import ExplorationType, set_exploration_type
+    from torchrl.objectives import ClipPPOLoss
+    from torchrl.objectives.ctrl import CTRLLoss
+    from torchrl.objectives.value.advantages import GAE
+    from torchrl.record import VideoRecorder
+    from torchrl.record.loggers import generate_exp_name, get_logger
+
+    from utils import eval_model, make_ctrl_ppo_models, make_parallel_env
+
+    torch.set_float32_matmul_precision("high")
+
+    # Set device
+    device = cfg.optim.device
+    if device in ("", None):
+        if torch.cuda.is_available():
+            device = "cuda:0"
+        else:
+            device = "cpu"
+    device = torch.device(device)
+
+    # Extract configuration
+    total_frames = cfg.collector.total_frames
+    frames_per_batch = cfg.collector.frames_per_batch
+    mini_batch_size = cfg.loss.mini_batch_size
+    test_interval = cfg.logger.test_interval
+
+    # Compile settings
+    compile_mode = None
+    if cfg.compile.compile:
+        compile_mode = cfg.compile.compile_mode
+        if compile_mode in ("", None):
+            if cfg.compile.cudagraphs:
+                compile_mode = "default"
+            else:
+                compile_mode = "reduce-overhead"
+
+    # Create models
+    encoder, actor, critic = make_ctrl_ppo_models(
+        cfg.env.env_name,
+        device=device,
+        gym_backend=cfg.env.backend,
+        embedding_dim=cfg.model.embedding_dim,
+        num_levels=cfg.env.num_levels,
+        distribution_mode=cfg.env.distribution_mode,
+    )
+
+    # Create collector
+    collector = SyncDataCollector(
+        create_env_fn=make_parallel_env(
+            cfg.env.env_name,
+            num_envs=cfg.env.num_envs,
+            device=device,
+            gym_backend=cfg.env.backend,
+            num_levels=cfg.env.num_levels,
+            distribution_mode=cfg.env.distribution_mode,
+        ),
+        policy=actor,
+        frames_per_batch=frames_per_batch,
+        total_frames=total_frames,
+        device=device,
+        max_frames_per_traj=-1,
+        compile_policy={"mode": compile_mode, "warmup": 1} if compile_mode else False,
+        cudagraph_policy={"warmup": 10} if cfg.compile.cudagraphs else False,
+    )
+
+    # Create data buffer
+    sampler = SamplerWithoutReplacement()
+    data_buffer = TensorDictReplayBuffer(
+        storage=LazyTensorStorage(
+            frames_per_batch, compilable=cfg.compile.compile, device=device
+        ),
+        sampler=sampler,
+        batch_size=mini_batch_size,
+        compilable=cfg.compile.compile,
+    )
+
+    # Create GAE advantage module
+    adv_module = GAE(
+        gamma=cfg.loss.gamma,
+        lmbda=cfg.loss.gae_lambda,
+        value_network=critic,
+        average_gae=False,
+        device=device,
+        vectorized=not cfg.compile.compile,
+    )
+
+    # Create PPO loss module
+    ppo_loss = ClipPPOLoss(
+        actor_network=actor,
+        critic_network=critic,
+        clip_epsilon=cfg.loss.clip_epsilon,
+        loss_critic_type=cfg.loss.loss_critic_type,
+        entropy_coeff=cfg.loss.entropy_coeff,
+        critic_coeff=cfg.loss.critic_coeff,
+        normalize_advantage=True,
+    )
+
+    # Create CTRL loss module
+    ctrl_loss = CTRLLoss(
+        encoder_network=encoder,
+        embedding_dim=cfg.model.embedding_dim,
+        projection_dim=cfg.ctrl.projection_dim,
+        num_prototypes=cfg.ctrl.num_prototypes,
+        sinkhorn_iters=cfg.ctrl.sinkhorn_iters,
+        temperature=cfg.ctrl.temperature,
+        window_len=cfg.ctrl.window_len,
+        myow_k=cfg.ctrl.myow_k,
+        myow_coeff=cfg.ctrl.myow_coeff,
+    )
+
+    # Create optimizers
+    # PPO optimizer (actor + critic)
+    ppo_optim = torch.optim.Adam(
+        ppo_loss.parameters(),
+        lr=cfg.optim.lr,
+        weight_decay=cfg.optim.weight_decay,
+        eps=cfg.optim.eps,
+    )
+
+    # CTRL optimizer (encoder + projection + prototypes)
+    ctrl_optim = torch.optim.Adam(
+        ctrl_loss.parameters(),
+        lr=cfg.optim.ctrl_lr,
+        weight_decay=cfg.optim.weight_decay,
+        eps=cfg.optim.eps,
+    )
+
+    # Create logger
+    logger = None
+    if cfg.logger.backend:
+        exp_name = generate_exp_name(
+            "CTRL-PPO", f"{cfg.logger.exp_name}_{cfg.env.env_name}"
+        )
+        logger = get_logger(
+            cfg.logger.backend,
+            logger_name="ctrl_ppo",
+            experiment_name=exp_name,
+            wandb_kwargs={
+                "config": dict(cfg),
+                "project": cfg.logger.project_name,
+                "group": cfg.logger.group_name,
+            },
+        )
+        logger_video = cfg.logger.video
+    else:
+        logger_video = False
+
+    # Create test environment (unseen levels for generalization testing)
+    test_env = make_parallel_env(
+        cfg.env.env_name,
+        1,
+        device,
+        is_test=True,
+        gym_backend=cfg.env.backend,
+        num_levels=cfg.env.num_levels,
+        distribution_mode=cfg.env.distribution_mode,
+    )
+    if logger_video:
+        test_env = test_env.insert_transform(
+            0,
+            VideoRecorder(logger, tag="rendering/test", in_keys=["pixels"], skip=4),
+        )
+    test_env.eval()
+
+    # Compile if requested
+    if compile_mode:
+        adv_module = torch.compile(adv_module, mode=compile_mode)
+        ppo_loss = torch.compile(ppo_loss, mode=compile_mode)
+        ctrl_loss = torch.compile(ctrl_loss, mode=compile_mode)
+
+    if cfg.compile.cudagraphs:
+        warnings.warn(
+            "CudaGraphModule is experimental and may lead to issues. "
+            "Use at your own risk.",
+            category=UserWarning,
+        )
+        adv_module = CudaGraphModule(adv_module, warmup=5)
+        ppo_loss = CudaGraphModule(ppo_loss, warmup=5)
+        ctrl_loss = CudaGraphModule(ctrl_loss, warmup=5)
+
+    # Training loop
+    collected_frames = 0
+    pbar = tqdm.tqdm(total=total_frames)
+
+    sampling_start = None
+    num_mini_batches = frames_per_batch // mini_batch_size
+    total_network_updates = (
+        (total_frames // frames_per_batch) * cfg.loss.ppo_epochs * num_mini_batches
+    )
+
+    # Learning rate scheduling
+    if cfg.optim.anneal_lr:
+        lr_scheduler = torch.optim.lr_scheduler.LinearLR(
+            ppo_optim,
+            start_factor=1.0,
+            end_factor=0.0,
+            total_iters=total_network_updates,
+        )
+        ctrl_lr_scheduler = torch.optim.lr_scheduler.LinearLR(
+            ctrl_optim,
+            start_factor=1.0,
+            end_factor=0.0,
+            total_iters=total_network_updates,
+        )
+
+    for i, data in enumerate(collector):
+        log_info = {}
+        sampling_time = timeit.get_elapsed() if sampling_start else 0
+        frames_in_batch = data.numel()
+        collected_frames += frames_in_batch
+        pbar.update(frames_in_batch)
+
+        # Get training rewards
+        episode_rewards = data["next", "episode_reward"][data["next", "done"]]
+        if len(episode_rewards) > 0:
+            episode_length = data["next", "step_count"][data["next", "done"]]
+            log_info.update(
+                {
+                    "train/reward": episode_rewards.mean().item(),
+                    "train/episode_length": episode_length.sum().item()
+                    / len(episode_length),
+                }
+            )
+
+        # Compute advantages
+        with torch.no_grad(), timeit("advantage"):
+            adv_module(data)
+        data_reshape = data.reshape(-1)
+
+        # PPO + CTRL training epochs
+        losses = TensorDict(batch_size=[cfg.loss.ppo_epochs, num_mini_batches])
+
+        with timeit("training"):
+            for epoch in range(cfg.loss.ppo_epochs):
+                data_buffer.extend(data_reshape)
+
+                for mb_idx, batch in enumerate(data_buffer):
+                    # PPO forward and backward
+                    ppo_optim.zero_grad()
+                    loss_td = ppo_loss(batch)
+
+                    # Backward PPO losses
+                    loss_ppo = (
+                        loss_td["loss_objective"]
+                        + loss_td["loss_entropy"]
+                        + loss_td["loss_critic"]
+                    )
+                    loss_ppo.backward()
+                    torch.nn.utils.clip_grad_norm_(
+                        ppo_loss.parameters(), cfg.optim.max_grad_norm
+                    )
+                    ppo_optim.step()
+
+                    # CTRL forward and backward
+                    ctrl_optim.zero_grad()
+                    ctrl_td = ctrl_loss(batch)
+                    loss_ctrl = ctrl_td["loss_ctrl"] * cfg.ctrl.ctrl_coeff
+                    loss_ctrl.backward()
+                    torch.nn.utils.clip_grad_norm_(
+                        ctrl_loss.parameters(), cfg.optim.max_grad_norm
+                    )
+                    ctrl_optim.step()
+
+                    # Combine loss info
+                    loss_td.update(ctrl_td)
+                    losses[epoch, mb_idx] = loss_td.select(
+                        "loss_objective",
+                        "loss_critic",
+                        "loss_entropy",
+                        "loss_ctrl",
+                        "loss_proto",
+                        "loss_myow",
+                        "entropy",
+                        "clip_fraction",
+                        "ESS",
+                    ).detach()
+
+                    if cfg.optim.anneal_lr:
+                        lr_scheduler.step()
+                        ctrl_lr_scheduler.step()
+
+        # Log training info
+        losses = losses.mean()
+        log_info.update(
+            {
+                "train/loss_objective": losses["loss_objective"].item(),
+                "train/loss_critic": losses["loss_critic"].item(),
+                "train/loss_entropy": losses["loss_entropy"].item(),
+                "train/loss_ctrl": losses["loss_ctrl"].item(),
+                "train/loss_proto": losses["loss_proto"].item(),
+                "train/loss_myow": losses["loss_myow"].item(),
+                "train/entropy": losses["entropy"].item(),
+                "train/clip_fraction": losses["clip_fraction"].item(),
+                "train/ESS": losses["ESS"].item(),
+                "train/lr": ppo_optim.param_groups[0]["lr"],
+                "train/ctrl_lr": ctrl_optim.param_groups[0]["lr"],
+                "train/sampling_time": sampling_time,
+                "train/training_time": timeit.get_elapsed("training"),
+            }
+        )
+
+        # Evaluation
+        with torch.no_grad(), set_exploration_type(
+            ExplorationType.DETERMINISTIC
+        ), timeit("eval"):
+            if ((i - 1) * frames_in_batch) // test_interval < (
+                i * frames_in_batch
+            ) // test_interval:
+                actor.eval()
+                test_reward = eval_model(
+                    actor, test_env, num_episodes=cfg.logger.num_test_episodes
+                )
+                log_info.update({"eval/reward": test_reward})
+                actor.train()
+
+        if logger:
+            for key, value in log_info.items():
+                logger.log_scalar(key, value, collected_frames)
+
+        sampling_start = timeit.get_elapsed()
+
+    collector.shutdown()
+    test_env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/sota-implementations/ctrl/utils.py
+++ b/sota-implementations/ctrl/utils.py
@@ -1,0 +1,394 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from tensordict.nn import TensorDictModule
+from torchrl.data.tensor_specs import CategoricalBox
+from torchrl.envs import (
+    DoubleToFloat,
+    EnvCreator,
+    ExplorationType,
+    GymEnv,
+    ParallelEnv,
+    RenameTransform,
+    Resize,
+    RewardSum,
+    set_gym_backend,
+    StepCounter,
+    ToTensorImage,
+    TransformedEnv,
+    VecNorm,
+)
+from torchrl.modules import ActorValueOperator, MLP, ProbabilisticActor, ValueOperator
+from torchrl.record import VideoRecorder
+
+
+# ====================================================================
+# Environment utils
+# --------------------------------------------------------------------
+
+
+def make_base_env(
+    env_name="procgen:procgen-coinrun-v0",
+    num_levels=200,
+    start_level=0,
+    distribution_mode="easy",
+    gym_backend="gymnasium",
+):
+    """Create a base Procgen environment.
+
+    Args:
+        env_name: Procgen environment name (e.g., "procgen:procgen-coinrun-v0")
+        num_levels: Number of unique levels to use for training
+        start_level: Starting level index
+        distribution_mode: Difficulty mode ("easy", "hard", "extreme")
+        gym_backend: Gym backend to use
+
+    Returns:
+        TransformedEnv: The base environment with minimal transforms
+    """
+    with set_gym_backend(gym_backend):
+        env = GymEnv(
+            env_name,
+            from_pixels=True,
+            pixels_only=False,
+            device="cpu",
+            categorical_action_encoding=True,
+            num_levels=num_levels,
+            start_level=start_level,
+            distribution_mode=distribution_mode,
+        )
+    env = TransformedEnv(env)
+    return env
+
+
+def make_parallel_env(
+    env_name,
+    num_envs,
+    device,
+    gym_backend,
+    num_levels=200,
+    start_level=0,
+    distribution_mode="easy",
+    is_test=False,
+):
+    """Create parallel Procgen environments with appropriate transforms.
+
+    Args:
+        env_name: Procgen environment name
+        num_envs: Number of parallel environments
+        device: Device to run environments on
+        gym_backend: Gym backend to use
+        num_levels: Number of unique levels (0 for unlimited in test mode)
+        start_level: Starting level index
+        distribution_mode: Difficulty mode
+        is_test: Whether this is a test environment
+
+    Returns:
+        TransformedEnv: Parallel environment with all transforms applied
+    """
+    if is_test:
+        # Use different levels for testing (generalization)
+        test_start_level = start_level + num_levels
+        test_num_levels = 0  # Unlimited levels for testing
+
+        env = ParallelEnv(
+            num_envs,
+            EnvCreator(
+                lambda: make_base_env(
+                    env_name,
+                    num_levels=test_num_levels,
+                    start_level=test_start_level,
+                    distribution_mode=distribution_mode,
+                    gym_backend=gym_backend,
+                )
+            ),
+            serial_for_single=True,
+            device=device,
+        )
+    else:
+        env = ParallelEnv(
+            num_envs,
+            EnvCreator(
+                lambda: make_base_env(
+                    env_name,
+                    num_levels=num_levels,
+                    start_level=start_level,
+                    distribution_mode=distribution_mode,
+                    gym_backend=gym_backend,
+                )
+            ),
+            serial_for_single=True,
+            device=device,
+        )
+
+    env = TransformedEnv(env)
+    # Procgen outputs RGB images, process them
+    env.append_transform(RenameTransform(in_keys=["pixels"], out_keys=["pixels_int"]))
+    env.append_transform(ToTensorImage(in_keys=["pixels_int"], out_keys=["pixels"]))
+    # Optionally convert to grayscale (comment out for RGB)
+    # env.append_transform(GrayScale())
+    env.append_transform(Resize(64, 64))  # Procgen default is 64x64
+    env.append_transform(RewardSum())
+    env.append_transform(
+        StepCounter(max_steps=1000)
+    )  # Procgen episodes are typically 1000 steps
+    env.append_transform(DoubleToFloat())
+    env.append_transform(VecNorm(in_keys=["pixels"]))
+
+    return env
+
+
+# ====================================================================
+# Model utils
+# --------------------------------------------------------------------
+
+
+class IMPALAEncoder(nn.Module):
+    """IMPALA-style CNN encoder as used in the CTRL paper.
+
+    This encoder uses residual blocks with the architecture from the
+    IMPALA paper, which is commonly used for Procgen environments.
+    """
+
+    def __init__(
+        self,
+        input_channels: int = 3,
+        depths: list[int] = None,
+        output_dim: int = 256,
+    ):
+        super().__init__()
+        if depths is None:
+            depths = [16, 32, 32]
+
+        self.depths = depths
+
+        # Build IMPALA-style conv blocks
+        layers = []
+        in_channels = input_channels
+
+        for depth in depths:
+            layers.append(
+                nn.Conv2d(in_channels, depth, kernel_size=3, stride=1, padding=1)
+            )
+            layers.append(nn.MaxPool2d(kernel_size=3, stride=2, padding=1))
+            # Two residual blocks
+            layers.append(self._make_residual_block(depth))
+            layers.append(self._make_residual_block(depth))
+            in_channels = depth
+
+        self.conv_layers = nn.Sequential(*layers)
+
+        # Calculate flattened size
+        # After 3 max pools with stride 2 on 64x64 input: 64 -> 32 -> 16 -> 8
+        self.flatten_size = depths[-1] * 8 * 8
+
+        self.fc = nn.Sequential(
+            nn.Flatten(),
+            nn.ReLU(),
+            nn.Linear(self.flatten_size, output_dim),
+            nn.ReLU(),
+        )
+
+    def _make_residual_block(self, channels: int) -> nn.Module:
+        """Create a residual block with two conv layers."""
+        return ResidualBlock(channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv_layers(x)
+        x = self.fc(x)
+        return x
+
+
+class ResidualBlock(nn.Module):
+    """Residual block with two conv layers."""
+
+    def __init__(self, channels: int):
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, stride=1, padding=1)
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, stride=1, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = nn.functional.relu(x)
+        x = self.conv1(x)
+        x = nn.functional.relu(x)
+        x = self.conv2(x)
+        return x + residual
+
+
+def make_ctrl_ppo_modules(proof_environment, device, embedding_dim=256):
+    """Create encoder, actor, and critic modules for CTRL+PPO.
+
+    Args:
+        proof_environment: Environment to get specs from
+        device: Device to create modules on
+        embedding_dim: Dimension of encoder output
+
+    Returns:
+        Tuple of (encoder_module, policy_module, value_module)
+    """
+    # Define input shape
+    input_shape = proof_environment.observation_spec["pixels"].shape
+
+    # Define distribution class and kwargs
+    if isinstance(proof_environment.action_spec_unbatched.space, CategoricalBox):
+        num_outputs = proof_environment.action_spec_unbatched.space.n
+        distribution_class = torch.distributions.Categorical
+        distribution_kwargs = {}
+    else:
+        raise ValueError("CTRL is designed for discrete action spaces (Procgen)")
+
+    # Create IMPALA encoder
+    input_channels = input_shape[0]  # Should be 3 for RGB
+    encoder = IMPALAEncoder(
+        input_channels=input_channels,
+        depths=[16, 32, 32],
+        output_dim=embedding_dim,
+    ).to(device)
+
+    # Wrap encoder as TensorDictModule
+    encoder_module = TensorDictModule(
+        module=encoder,
+        in_keys=["pixels"],
+        out_keys=["embedding"],
+    )
+
+    # Define policy head
+    policy_net = MLP(
+        in_features=embedding_dim,
+        out_features=num_outputs,
+        activation_class=nn.ReLU,
+        num_cells=[],
+        device=device,
+    )
+    policy_module = TensorDictModule(
+        module=policy_net,
+        in_keys=["embedding"],
+        out_keys=["logits"],
+    )
+
+    # Add probabilistic sampling
+    policy_module = ProbabilisticActor(
+        policy_module,
+        in_keys=["logits"],
+        spec=proof_environment.full_action_spec_unbatched.to(device),
+        distribution_class=distribution_class,
+        distribution_kwargs=distribution_kwargs,
+        return_log_prob=True,
+        default_interaction_type=ExplorationType.RANDOM,
+    )
+
+    # Define value head
+    value_net = MLP(
+        activation_class=nn.ReLU,
+        in_features=embedding_dim,
+        out_features=1,
+        num_cells=[],
+        device=device,
+    )
+    value_module = ValueOperator(
+        value_net,
+        in_keys=["embedding"],
+    )
+
+    return encoder_module, policy_module, value_module
+
+
+def make_ctrl_ppo_models(
+    env_name,
+    device,
+    gym_backend,
+    embedding_dim=256,
+    num_levels=200,
+    distribution_mode="easy",
+):
+    """Create complete actor-critic models for CTRL+PPO.
+
+    Args:
+        env_name: Procgen environment name
+        device: Device to create models on
+        gym_backend: Gym backend to use
+        embedding_dim: Dimension of encoder output
+        num_levels: Number of training levels
+        distribution_mode: Difficulty mode
+
+    Returns:
+        Tuple of (encoder, actor, critic) modules
+    """
+    proof_environment = make_parallel_env(
+        env_name,
+        1,
+        device=device,
+        gym_backend=gym_backend,
+        num_levels=num_levels,
+        distribution_mode=distribution_mode,
+    )
+
+    encoder_module, policy_module, value_module = make_ctrl_ppo_modules(
+        proof_environment,
+        device=device,
+        embedding_dim=embedding_dim,
+    )
+
+    # Wrap modules in ActorValueOperator for shared encoder
+    actor_critic = ActorValueOperator(
+        common_operator=encoder_module,
+        policy_operator=policy_module,
+        value_operator=value_module,
+    )
+
+    with torch.no_grad():
+        td = proof_environment.fake_tensordict().expand(10)
+        actor_critic(td)
+        del td
+
+    actor = actor_critic.get_policy_operator()
+    critic = actor_critic.get_value_operator()
+
+    del proof_environment
+
+    # Return encoder separately for CTRL loss
+    return encoder_module, actor, critic
+
+
+# ====================================================================
+# Evaluation utils
+# --------------------------------------------------------------------
+
+
+def dump_video(module):
+    """Dump video if module is a VideoRecorder."""
+    if isinstance(module, VideoRecorder):
+        module.dump()
+
+
+def eval_model(actor, test_env, num_episodes=10):
+    """Evaluate model on test environment.
+
+    Args:
+        actor: Actor policy to evaluate
+        test_env: Test environment
+        num_episodes: Number of episodes to evaluate
+
+    Returns:
+        Mean episode reward
+    """
+    test_rewards = []
+    for _ in range(num_episodes):
+        td_test = test_env.rollout(
+            policy=actor,
+            auto_reset=True,
+            auto_cast_to_device=True,
+            break_when_any_done=True,
+            max_steps=1000,
+        )
+        test_env.apply(dump_video)
+        reward = td_test["next", "episode_reward"][td_test["next", "done"]]
+        test_rewards.append(reward.cpu())
+    del td_test
+    return torch.cat(test_rewards, 0).mean()

--- a/test/test_ctrl.py
+++ b/test/test_ctrl.py
@@ -1,0 +1,509 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+from tensordict import TensorDict
+from tensordict.nn import TensorDictModule
+
+from torchrl.objectives.ctrl import CTRLLoss, CTRLPPOLoss
+
+
+class TestCTRLLoss:
+    """Tests for CTRLLoss module."""
+
+    seed = 0
+
+    def _create_mock_encoder(
+        self,
+        obs_dim=64,
+        embedding_dim=128,
+        device="cpu",
+        observation_key="observation",
+        embedding_key="embedding",
+    ):
+        """Create a mock encoder network."""
+        net = nn.Sequential(
+            nn.Linear(obs_dim, 256),
+            nn.ReLU(),
+            nn.Linear(256, embedding_dim),
+        )
+        encoder = TensorDictModule(
+            net,
+            in_keys=[observation_key],
+            out_keys=[embedding_key],
+        )
+        return encoder.to(device)
+
+    def _create_mock_data(
+        self,
+        batch_size=32,
+        obs_dim=64,
+        device="cpu",
+        observation_key="observation",
+    ):
+        """Create mock trajectory data."""
+        torch.manual_seed(self.seed)
+        data = TensorDict(
+            {
+                observation_key: torch.randn(batch_size, obs_dim, device=device),
+            },
+            batch_size=[batch_size],
+            device=device,
+        )
+        return data
+
+    @pytest.mark.parametrize(
+        "device", ["cpu", "cuda:0"] if torch.cuda.is_available() else ["cpu"]
+    )
+    @pytest.mark.parametrize("embedding_dim", [64, 128, 256])
+    def test_ctrl_loss_forward(self, device, embedding_dim):
+        """Test basic forward pass of CTRLLoss."""
+        torch.manual_seed(self.seed)
+
+        encoder = self._create_mock_encoder(
+            obs_dim=64,
+            embedding_dim=embedding_dim,
+            device=device,
+        )
+        loss_fn = CTRLLoss(
+            encoder_network=encoder,
+            embedding_dim=embedding_dim,
+            projection_dim=64,
+            num_prototypes=128,
+        ).to(device)
+
+        data = self._create_mock_data(batch_size=32, obs_dim=64, device=device)
+        loss_td = loss_fn(data)
+
+        # Check output keys
+        assert "loss_ctrl" in loss_td.keys()
+        assert "loss_proto" in loss_td.keys()
+        assert "loss_myow" in loss_td.keys()
+
+        # Check loss values are valid
+        assert torch.isfinite(loss_td["loss_ctrl"]).all()
+        assert torch.isfinite(loss_td["loss_proto"]).all()
+        assert torch.isfinite(loss_td["loss_myow"]).all()
+
+        # Check shapes (should be scalar after reduction)
+        assert loss_td["loss_ctrl"].shape == torch.Size([])
+
+    @pytest.mark.parametrize(
+        "device", ["cpu", "cuda:0"] if torch.cuda.is_available() else ["cpu"]
+    )
+    def test_ctrl_loss_backward(self, device):
+        """Test that gradients flow through CTRLLoss."""
+        torch.manual_seed(self.seed)
+
+        encoder = self._create_mock_encoder(
+            obs_dim=64,
+            embedding_dim=128,
+            device=device,
+        )
+        loss_fn = CTRLLoss(
+            encoder_network=encoder,
+            embedding_dim=128,
+            projection_dim=64,
+            num_prototypes=128,
+        ).to(device)
+
+        data = self._create_mock_data(batch_size=32, obs_dim=64, device=device)
+        loss_td = loss_fn(data)
+
+        total_loss = loss_td["loss_ctrl"]
+        total_loss.backward()
+
+        # Check that gradients exist for projection head
+        for param in loss_fn.projection_head.parameters():
+            assert param.grad is not None
+            assert torch.isfinite(param.grad).all()
+
+        # Check that gradients exist for prototypes
+        assert loss_fn.prototypes.grad is not None
+        assert torch.isfinite(loss_fn.prototypes.grad).all()
+
+    @pytest.mark.parametrize("num_prototypes", [64, 256, 512])
+    def test_ctrl_loss_prototype_count(self, num_prototypes):
+        """Test CTRLLoss with different prototype counts."""
+        torch.manual_seed(self.seed)
+
+        encoder = self._create_mock_encoder(obs_dim=64, embedding_dim=128)
+        loss_fn = CTRLLoss(
+            encoder_network=encoder,
+            embedding_dim=128,
+            projection_dim=64,
+            num_prototypes=num_prototypes,
+        )
+
+        # Check prototype dimensions
+        assert loss_fn.prototypes.shape == (num_prototypes, 64)
+
+        data = self._create_mock_data(batch_size=32, obs_dim=64)
+        loss_td = loss_fn(data)
+
+        assert torch.isfinite(loss_td["loss_ctrl"]).all()
+
+    @pytest.mark.parametrize("sinkhorn_iters", [1, 3, 5])
+    def test_ctrl_loss_sinkhorn_iters(self, sinkhorn_iters):
+        """Test CTRLLoss with different Sinkhorn iteration counts."""
+        torch.manual_seed(self.seed)
+
+        encoder = self._create_mock_encoder(obs_dim=64, embedding_dim=128)
+        loss_fn = CTRLLoss(
+            encoder_network=encoder,
+            embedding_dim=128,
+            projection_dim=64,
+            num_prototypes=128,
+            sinkhorn_iters=sinkhorn_iters,
+        )
+
+        data = self._create_mock_data(batch_size=32, obs_dim=64)
+        loss_td = loss_fn(data)
+
+        assert torch.isfinite(loss_td["loss_ctrl"]).all()
+
+    @pytest.mark.parametrize("temperature", [0.05, 0.1, 0.5])
+    def test_ctrl_loss_temperature(self, temperature):
+        """Test CTRLLoss with different temperature values."""
+        torch.manual_seed(self.seed)
+
+        encoder = self._create_mock_encoder(obs_dim=64, embedding_dim=128)
+        loss_fn = CTRLLoss(
+            encoder_network=encoder,
+            embedding_dim=128,
+            projection_dim=64,
+            num_prototypes=128,
+            temperature=temperature,
+        )
+
+        data = self._create_mock_data(batch_size=32, obs_dim=64)
+        loss_td = loss_fn(data)
+
+        assert torch.isfinite(loss_td["loss_ctrl"]).all()
+
+    @pytest.mark.parametrize("myow_coeff", [0.0, 0.5, 1.0, 2.0])
+    def test_ctrl_loss_myow_coeff(self, myow_coeff):
+        """Test CTRLLoss with different MYOW coefficients."""
+        torch.manual_seed(self.seed)
+
+        encoder = self._create_mock_encoder(obs_dim=64, embedding_dim=128)
+        loss_fn = CTRLLoss(
+            encoder_network=encoder,
+            embedding_dim=128,
+            projection_dim=64,
+            num_prototypes=128,
+            myow_coeff=myow_coeff,
+        )
+
+        data = self._create_mock_data(batch_size=32, obs_dim=64)
+        loss_td = loss_fn(data)
+
+        assert torch.isfinite(loss_td["loss_ctrl"]).all()
+
+    @pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+    def test_ctrl_loss_reduction(self, reduction):
+        """Test CTRLLoss with different reduction modes."""
+        torch.manual_seed(self.seed)
+
+        encoder = self._create_mock_encoder(obs_dim=64, embedding_dim=128)
+        loss_fn = CTRLLoss(
+            encoder_network=encoder,
+            embedding_dim=128,
+            projection_dim=64,
+            num_prototypes=128,
+            reduction=reduction,
+        )
+
+        batch_size = 32
+        data = self._create_mock_data(batch_size=batch_size, obs_dim=64)
+        loss_td = loss_fn(data)
+
+        if reduction == "none":
+            # Should not be reduced to scalar
+            assert loss_td["loss_ctrl"].numel() > 1
+        else:
+            # Should be scalar
+            assert loss_td["loss_ctrl"].shape == torch.Size([])
+
+    def test_ctrl_loss_in_keys(self):
+        """Test that in_keys are correctly set."""
+        encoder = self._create_mock_encoder(obs_dim=64, embedding_dim=128)
+        loss_fn = CTRLLoss(
+            encoder_network=encoder,
+            embedding_dim=128,
+        )
+
+        assert "observation" in loss_fn.in_keys
+
+    def test_ctrl_loss_out_keys(self):
+        """Test that out_keys are correctly set."""
+        encoder = self._create_mock_encoder(obs_dim=64, embedding_dim=128)
+        loss_fn = CTRLLoss(
+            encoder_network=encoder,
+            embedding_dim=128,
+        )
+
+        assert "loss_ctrl" in loss_fn.out_keys
+        assert "loss_proto" in loss_fn.out_keys
+        assert "loss_myow" in loss_fn.out_keys
+
+    def test_ctrl_loss_set_keys(self):
+        """Test setting custom tensordict keys."""
+        encoder = self._create_mock_encoder(
+            obs_dim=64,
+            embedding_dim=128,
+            observation_key="obs",
+            embedding_key="hidden",
+        )
+        loss_fn = CTRLLoss(
+            encoder_network=encoder,
+            embedding_dim=128,
+        )
+        loss_fn.set_keys(observation="obs", embedding="hidden")
+
+        assert loss_fn.tensor_keys.observation == "obs"
+        assert loss_fn.tensor_keys.embedding == "hidden"
+
+    def test_ctrl_loss_missing_observation_key(self):
+        """Test that error is raised when observation key is missing."""
+        encoder = self._create_mock_encoder(obs_dim=64, embedding_dim=128)
+        loss_fn = CTRLLoss(
+            encoder_network=encoder,
+            embedding_dim=128,
+        )
+
+        # Create data without the observation key
+        data = TensorDict(
+            {"other_key": torch.randn(32, 64)},
+            batch_size=[32],
+        )
+
+        with pytest.raises(KeyError):
+            loss_fn(data)
+
+    @pytest.mark.parametrize("batch_size", [8, 32, 64])
+    def test_ctrl_loss_batch_sizes(self, batch_size):
+        """Test CTRLLoss with different batch sizes."""
+        torch.manual_seed(self.seed)
+
+        encoder = self._create_mock_encoder(obs_dim=64, embedding_dim=128)
+        loss_fn = CTRLLoss(
+            encoder_network=encoder,
+            embedding_dim=128,
+            projection_dim=64,
+            num_prototypes=128,
+        )
+
+        data = self._create_mock_data(batch_size=batch_size, obs_dim=64)
+        loss_td = loss_fn(data)
+
+        assert torch.isfinite(loss_td["loss_ctrl"]).all()
+
+    def test_sinkhorn_algorithm(self):
+        """Test that Sinkhorn algorithm produces valid soft assignments."""
+        torch.manual_seed(self.seed)
+
+        # Create random scores
+        scores = torch.randn(32, 128)
+
+        # Apply Sinkhorn
+        Q = CTRLLoss._sinkhorn(scores, iters=3)
+
+        # Check that output is valid probability distribution
+        assert torch.isfinite(Q).all()
+        assert (Q >= 0).all()
+        # Rows should sum to approximately 1
+        row_sums = Q.sum(dim=1)
+        assert torch.allclose(row_sums, torch.ones_like(row_sums), atol=1e-3)
+
+    def test_sinkhorn_convergence(self):
+        """Test that more Sinkhorn iterations lead to better normalization."""
+        torch.manual_seed(self.seed)
+
+        scores = torch.randn(32, 128)
+
+        Q1 = CTRLLoss._sinkhorn(scores, iters=1)
+        Q3 = CTRLLoss._sinkhorn(scores, iters=3)
+        Q10 = CTRLLoss._sinkhorn(scores, iters=10)
+
+        # All should be valid
+        for Q in [Q1, Q3, Q10]:
+            assert torch.isfinite(Q).all()
+            assert (Q >= 0).all()
+
+
+class TestCTRLPPOLoss:
+    """Tests for combined CTRL+PPO loss."""
+
+    seed = 0
+
+    def _create_mock_encoder(self, obs_dim=64, embedding_dim=128, device="cpu"):
+        """Create a mock encoder network."""
+        net = nn.Sequential(
+            nn.Linear(obs_dim, 256),
+            nn.ReLU(),
+            nn.Linear(256, embedding_dim),
+        )
+        encoder = TensorDictModule(
+            net,
+            in_keys=["observation"],
+            out_keys=["embedding"],
+        )
+        return encoder.to(device)
+
+    def _create_mock_ppo_loss(
+        self, obs_dim=64, embedding_dim=128, action_dim=4, device="cpu"
+    ):
+        """Create a mock PPO loss module."""
+        from torchrl.data.tensor_specs import Bounded
+        from torchrl.modules import ProbabilisticActor, TanhNormal, ValueOperator
+        from torchrl.modules.distributions import NormalParamExtractor
+        from torchrl.objectives import ClipPPOLoss
+
+        # Actor
+        action_spec = Bounded(
+            -torch.ones(action_dim), torch.ones(action_dim), (action_dim,)
+        )
+        net = nn.Sequential(
+            nn.Linear(obs_dim, embedding_dim),
+            nn.ReLU(),
+            nn.Linear(embedding_dim, 2 * action_dim),
+            NormalParamExtractor(),
+        )
+        module = TensorDictModule(
+            net, in_keys=["observation"], out_keys=["loc", "scale"]
+        )
+        actor = ProbabilisticActor(
+            module=module,
+            distribution_class=TanhNormal,
+            in_keys=["loc", "scale"],
+            out_keys=["action"],
+            spec=action_spec,
+            return_log_prob=True,
+        ).to(device)
+
+        # Critic
+        value_net = nn.Sequential(
+            nn.Linear(obs_dim, embedding_dim),
+            nn.ReLU(),
+            nn.Linear(embedding_dim, 1),
+        )
+        critic = ValueOperator(
+            value_net,
+            in_keys=["observation"],
+        ).to(device)
+
+        return ClipPPOLoss(actor, critic)
+
+    def _create_mock_data(
+        self,
+        batch_size=32,
+        obs_dim=64,
+        action_dim=4,
+        device="cpu",
+    ):
+        """Create mock data for CTRL+PPO."""
+        torch.manual_seed(self.seed)
+        data = TensorDict(
+            {
+                "observation": torch.randn(batch_size, obs_dim, device=device),
+                "action": torch.randn(batch_size, action_dim, device=device),
+                "action_log_prob": torch.randn(batch_size, device=device),
+                ("next", "observation"): torch.randn(
+                    batch_size, obs_dim, device=device
+                ),
+                ("next", "reward"): torch.randn(batch_size, 1, device=device),
+                ("next", "done"): torch.zeros(
+                    batch_size, 1, dtype=torch.bool, device=device
+                ),
+                ("next", "terminated"): torch.zeros(
+                    batch_size, 1, dtype=torch.bool, device=device
+                ),
+            },
+            batch_size=[batch_size],
+            device=device,
+        )
+        return data
+
+    def test_ctrl_ppo_loss_forward(self):
+        """Test combined CTRL+PPO loss forward pass."""
+        torch.manual_seed(self.seed)
+
+        ppo_loss = self._create_mock_ppo_loss()
+        encoder = self._create_mock_encoder()
+        ctrl_loss = CTRLLoss(encoder_network=encoder, embedding_dim=128)
+
+        combined_loss = CTRLPPOLoss(ppo_loss, ctrl_loss, ctrl_coeff=1.0)
+
+        data = self._create_mock_data()
+        loss_td = combined_loss(data)
+
+        # Check PPO outputs
+        assert "loss_objective" in loss_td.keys()
+        assert "loss_critic" in loss_td.keys()
+
+        # Check CTRL outputs
+        assert "loss_ctrl" in loss_td.keys()
+        assert "loss_proto" in loss_td.keys()
+        assert "loss_myow" in loss_td.keys()
+
+    def test_ctrl_ppo_loss_ctrl_coeff(self):
+        """Test that ctrl_coeff scales CTRL loss correctly."""
+        torch.manual_seed(self.seed)
+
+        ppo_loss = self._create_mock_ppo_loss()
+        encoder = self._create_mock_encoder()
+        ctrl_loss = CTRLLoss(encoder_network=encoder, embedding_dim=128)
+
+        # Test with different coefficients
+        for coeff in [0.5, 1.0, 2.0]:
+            combined_loss = CTRLPPOLoss(ppo_loss, ctrl_loss, ctrl_coeff=coeff)
+            data = self._create_mock_data()
+
+            # Get standalone CTRL loss
+            ctrl_td = ctrl_loss(data)
+            expected_ctrl_loss = ctrl_td["loss_ctrl"] * coeff
+
+            # Get combined loss
+            combined_td = combined_loss(data)
+
+            # The scaled loss should match
+            assert torch.allclose(
+                combined_td["loss_ctrl"],
+                expected_ctrl_loss,
+                atol=1e-5,
+            )
+
+    def test_ctrl_ppo_loss_in_keys(self):
+        """Test that in_keys include both PPO and CTRL keys."""
+        ppo_loss = self._create_mock_ppo_loss()
+        encoder = self._create_mock_encoder()
+        ctrl_loss = CTRLLoss(encoder_network=encoder, embedding_dim=128)
+
+        combined_loss = CTRLPPOLoss(ppo_loss, ctrl_loss)
+
+        # Should include observation (for both PPO and CTRL)
+        assert "observation" in combined_loss.in_keys
+
+    def test_ctrl_ppo_loss_out_keys(self):
+        """Test that out_keys include both PPO and CTRL keys."""
+        ppo_loss = self._create_mock_ppo_loss()
+        encoder = self._create_mock_encoder()
+        ctrl_loss = CTRLLoss(encoder_network=encoder, embedding_dim=128)
+
+        combined_loss = CTRLPPOLoss(ppo_loss, ctrl_loss)
+
+        # Should include PPO keys
+        assert "loss_objective" in combined_loss.out_keys
+
+        # Should include CTRL keys
+        assert "loss_ctrl" in combined_loss.out_keys
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/torchrl/objectives/__init__.py
+++ b/torchrl/objectives/__init__.py
@@ -7,6 +7,7 @@ from torchrl.objectives.a2c import A2CLoss
 from torchrl.objectives.common import add_random_module, LossModule
 from torchrl.objectives.cql import CQLLoss, DiscreteCQLLoss
 from torchrl.objectives.crossq import CrossQLoss
+from torchrl.objectives.ctrl import CTRLLoss, CTRLPPOLoss
 from torchrl.objectives.ddpg import DDPGLoss
 from torchrl.objectives.decision_transformer import DTLoss, OnlineDTLoss
 from torchrl.objectives.dqn import DistributionalDQNLoss, DQNLoss
@@ -40,6 +41,8 @@ from torchrl.objectives.utils import (
 __all__ = [
     "A2CLoss",
     "CQLLoss",
+    "CTRLLoss",
+    "CTRLPPOLoss",
     "ClipPPOLoss",
     "CrossQLoss",
     "DDPGLoss",

--- a/torchrl/objectives/ctrl.py
+++ b/torchrl/objectives/ctrl.py
@@ -1,0 +1,538 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+from tensordict import TensorDict, TensorDictBase
+from tensordict.nn import dispatch, TensorDictModule
+from tensordict.utils import NestedKey
+from torch import nn
+
+from torchrl.objectives.common import LossModule
+from torchrl.objectives.utils import _reduce
+
+
+class CTRLLoss(LossModule):
+    """Cross-Trajectory Representation Learning (CTRL) Loss.
+
+    CTRL is a self-supervised representation learning method for RL that improves
+    zero-shot generalization by training encoders to recognize behavioral similarity
+    across trajectories without using rewards.
+
+    The loss combines:
+    - Prototype-based contrastive learning using Sinkhorn algorithm for soft cluster assignments
+    - MYOW (Make Your Own Winners) loss for cross-trajectory representation consistency
+
+    Reference: "Cross-Trajectory Representation Learning for Zero-Shot Generalization in RL"
+    https://arxiv.org/abs/2106.02193
+
+    Args:
+        encoder_network (TensorDictModule): The encoder network that produces representations.
+            This is typically the shared encoder used by both actor and critic.
+        embedding_dim (int): Dimension of the encoder output embeddings.
+
+    Keyword Args:
+        projection_dim (int, optional): Dimension of the projection space for prototypes.
+            Defaults to 128.
+        num_prototypes (int, optional): Number of learnable prototype vectors.
+            Defaults to 512.
+        sinkhorn_iters (int, optional): Number of Sinkhorn-Knopp iterations for
+            computing soft cluster assignments. Defaults to 3.
+        temperature (float, optional): Temperature parameter for softmax and Sinkhorn.
+            Lower values make assignments more peaked. Defaults to 0.1.
+        window_len (int, optional): Length of sliding window for trajectory segments.
+            Defaults to 4.
+        myow_k (int, optional): Number of nearest prototypes to consider in MYOW loss.
+            Defaults to 5.
+        myow_coeff (float, optional): Coefficient for the MYOW loss term.
+            Defaults to 1.0.
+        reduction (str, optional): Specifies the reduction to apply to the output:
+            ``"none"`` | ``"mean"`` | ``"sum"``. Defaults to ``"mean"``.
+
+    Examples:
+        >>> import torch
+        >>> from tensordict import TensorDict
+        >>> from tensordict.nn import TensorDictModule
+        >>> from torchrl.objectives.ctrl import CTRLLoss
+        >>> # Create a simple encoder
+        >>> encoder = TensorDictModule(
+        ...     nn.Sequential(nn.Linear(64, 256), nn.ReLU(), nn.Linear(256, 128)),
+        ...     in_keys=["observation"],
+        ...     out_keys=["embedding"]
+        ... )
+        >>> # Create CTRL loss
+        >>> ctrl_loss = CTRLLoss(encoder, embedding_dim=128)
+        >>> # Create sample data (batch of trajectory windows)
+        >>> batch_size = 32
+        >>> window_len = 4
+        >>> data = TensorDict({
+        ...     "observation": torch.randn(batch_size, window_len, 64),
+        ... }, batch_size=[batch_size, window_len])
+        >>> # Compute loss
+        >>> loss_td = ctrl_loss(data)
+        >>> loss_td["loss_ctrl"]
+        tensor(..., grad_fn=<...>)
+    """
+
+    @dataclass
+    class _AcceptedKeys:
+        """Maintains default values for all configurable tensordict keys.
+
+        This class defines which tensordict keys can be set using
+        '.set_keys(key_name=key_value)' and their default values.
+
+        Attributes:
+            observation (NestedKey): The input tensordict key for observations.
+                Defaults to ``"observation"``.
+            embedding (NestedKey): The output key for encoder embeddings.
+                Defaults to ``"embedding"``.
+        """
+
+        observation: NestedKey = "observation"
+        embedding: NestedKey = "embedding"
+
+    default_keys = _AcceptedKeys
+    tensor_keys: _AcceptedKeys
+
+    encoder_network: TensorDictModule
+
+    def __init__(
+        self,
+        encoder_network: TensorDictModule,
+        embedding_dim: int,
+        *,
+        projection_dim: int = 128,
+        num_prototypes: int = 512,
+        sinkhorn_iters: int = 3,
+        temperature: float = 0.1,
+        window_len: int = 4,
+        myow_k: int = 5,
+        myow_coeff: float = 1.0,
+        reduction: str | None = None,
+    ):
+        if reduction is None:
+            reduction = "mean"
+
+        self._in_keys = None
+        self._out_keys = None
+        super().__init__()
+
+        # Store the encoder network (not functionalized - we just use it for forward passes)
+        self.encoder_network = encoder_network
+        self.embedding_dim = embedding_dim
+
+        # Hyperparameters
+        self.register_buffer("temperature", torch.tensor(temperature))
+        self.register_buffer("sinkhorn_iters", torch.tensor(sinkhorn_iters))
+        self.register_buffer("myow_k", torch.tensor(myow_k))
+        self.register_buffer("myow_coeff", torch.tensor(myow_coeff))
+        self.window_len = window_len
+        self.reduction = reduction
+
+        # Projection head: maps encoder output to projection space
+        self.projection_head = nn.Sequential(
+            nn.Linear(embedding_dim, embedding_dim),
+            nn.ReLU(),
+            nn.Linear(embedding_dim, projection_dim),
+        )
+
+        # Prediction head: for contrastive prediction
+        self.prediction_head = nn.Sequential(
+            nn.Linear(projection_dim, projection_dim),
+            nn.ReLU(),
+            nn.Linear(projection_dim, projection_dim),
+        )
+
+        # Learnable prototype vectors
+        self.prototypes = nn.Parameter(torch.randn(num_prototypes, projection_dim))
+        nn.init.xavier_uniform_(self.prototypes)
+
+        self.num_prototypes = num_prototypes
+        self.projection_dim = projection_dim
+
+    @property
+    def functional(self):
+        """CTRL loss is not functional - it uses the encoder directly."""
+        return False
+
+    def _set_in_keys(self):
+        keys = list(self.encoder_network.in_keys)
+        self._in_keys = list(set(keys))
+
+    @property
+    def in_keys(self):
+        if self._in_keys is None:
+            self._set_in_keys()
+        return self._in_keys
+
+    @in_keys.setter
+    def in_keys(self, values):
+        self._in_keys = values
+
+    @property
+    def out_keys(self):
+        if self._out_keys is None:
+            self._out_keys = ["loss_ctrl", "loss_proto", "loss_myow"]
+        return self._out_keys
+
+    @out_keys.setter
+    def out_keys(self, values):
+        self._out_keys = values
+
+    def _forward_value_estimator_keys(self, **kwargs) -> None:
+        """CTRL does not use a value estimator."""
+        pass
+
+    @staticmethod
+    def _sinkhorn(
+        scores: torch.Tensor, iters: int = 3, epsilon: float = 1e-8
+    ) -> torch.Tensor:
+        """Apply Sinkhorn-Knopp algorithm for balanced soft assignments.
+
+        The Sinkhorn algorithm iteratively normalizes rows and columns to obtain
+        a doubly-stochastic matrix, which provides balanced cluster assignments.
+
+        Args:
+            scores: Similarity scores of shape (batch_size, num_prototypes)
+            iters: Number of Sinkhorn iterations
+            epsilon: Small constant for numerical stability
+
+        Returns:
+            Soft assignment matrix of shape (batch_size, num_prototypes)
+        """
+        Q = torch.exp(scores)
+        Q = Q / (Q.sum(dim=0, keepdim=True) + epsilon)
+
+        for _ in range(iters):
+            # Row normalization
+            Q = Q / (Q.sum(dim=1, keepdim=True) + epsilon)
+            # Column normalization
+            Q = Q / (Q.sum(dim=0, keepdim=True) + epsilon)
+
+        # Final row normalization to get proper probabilities
+        Q = Q / (Q.sum(dim=1, keepdim=True) + epsilon)
+        return Q
+
+    def _compute_prototype_loss(
+        self,
+        z: torch.Tensor,
+        p: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute prototype-based contrastive loss.
+
+        Uses the prediction head output and Sinkhorn assignments to compute
+        a cross-entropy loss that encourages consistent prototype assignments.
+
+        Args:
+            z: Projected embeddings of shape (batch_size, projection_dim)
+            p: Predicted embeddings of shape (batch_size, projection_dim)
+
+        Returns:
+            Prototype loss scalar
+        """
+        # Normalize prototypes and embeddings
+        prototypes = F.normalize(self.prototypes, dim=1)
+        z_norm = F.normalize(z, dim=1)
+        p_norm = F.normalize(p, dim=1)
+
+        # Compute similarity scores
+        scores_z = torch.mm(z_norm, prototypes.t()) / self.temperature
+        scores_p = torch.mm(p_norm, prototypes.t()) / self.temperature
+
+        # Get soft assignments using Sinkhorn (stop gradient for targets)
+        with torch.no_grad():
+            q_target = self._sinkhorn(
+                scores_z.detach(), int(self.sinkhorn_iters.item())
+            )
+
+        # Cross-entropy loss between predictions and targets
+        log_p = F.log_softmax(scores_p, dim=1)
+        loss = -torch.sum(q_target * log_p, dim=1)
+
+        return loss
+
+    def _compute_myow_loss(
+        self,
+        z1: torch.Tensor,
+        z2: torch.Tensor,
+    ) -> torch.Tensor:
+        """Compute MYOW (Make Your Own Winners) loss.
+
+        MYOW encourages representations from different trajectories that map
+        to nearby prototypes to be similar, promoting cross-trajectory consistency.
+
+        Args:
+            z1: Projected embeddings from first trajectory segment (batch_size, projection_dim)
+            z2: Projected embeddings from second trajectory segment (batch_size, projection_dim)
+
+        Returns:
+            MYOW loss scalar
+        """
+        # Normalize prototypes and embeddings
+        prototypes = F.normalize(self.prototypes, dim=1)
+        z1_norm = F.normalize(z1, dim=1)
+        z2_norm = F.normalize(z2, dim=1)
+
+        # Compute distances to prototypes
+        dist1 = torch.cdist(z1_norm, prototypes)  # (batch_size, num_prototypes)
+        dist2 = torch.cdist(z2_norm, prototypes)  # (batch_size, num_prototypes)
+
+        # Find k nearest prototypes for each embedding
+        k = min(int(self.myow_k.item()), self.num_prototypes)
+        _, indices1 = torch.topk(dist1, k, dim=1, largest=False)  # (batch_size, k)
+        _, indices2 = torch.topk(dist2, k, dim=1, largest=False)  # (batch_size, k)
+
+        # Find samples that share at least one prototype in their top-k
+        # Create binary masks for prototype membership
+        mask1 = torch.zeros(z1.shape[0], self.num_prototypes, device=z1.device)
+        mask2 = torch.zeros(z2.shape[0], self.num_prototypes, device=z2.device)
+        mask1.scatter_(1, indices1, 1.0)
+        mask2.scatter_(1, indices2, 1.0)
+
+        # Compute overlap: (batch_size, batch_size) matrix
+        overlap = torch.mm(mask1, mask2.t())  # Number of shared prototypes
+        neighbors = overlap > 0  # Boolean mask for pairs with shared prototypes
+
+        if not neighbors.any():
+            # No neighbors found, return zero loss
+            return torch.zeros(z1.shape[0], device=z1.device)
+
+        # Compute cosine similarity between all pairs
+        similarity = torch.mm(z1_norm, z2_norm.t())  # (batch_size, batch_size)
+
+        # MYOW loss: maximize similarity for neighbor pairs
+        # We use 1 - similarity as the loss (want to minimize distance)
+        loss_matrix = 1 - similarity
+
+        # Mask out non-neighbor pairs and compute mean loss per sample
+        loss_matrix = loss_matrix * neighbors.float()
+        num_neighbors = neighbors.float().sum(dim=1).clamp(min=1)
+        loss = loss_matrix.sum(dim=1) / num_neighbors
+
+        return loss
+
+    def _extract_windows(
+        self, observations: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Extract two sets of windows from trajectory observations for cross-trajectory comparison.
+
+        For CTRL, we need to compare representations across different trajectory
+        segments. This function splits the batch into two halves for comparison.
+
+        Args:
+            observations: Observations of shape (batch_size, window_len, *obs_shape)
+                or (batch_size, *obs_shape)
+
+        Returns:
+            Tuple of two observation tensors for comparison
+        """
+        # If observations don't have a time dimension, just split the batch
+        if observations.dim() == 2 or (
+            observations.dim() > 2 and observations.shape[1] != self.window_len
+        ):
+            # No time dimension or time dimension doesn't match window_len
+            # Split batch in half for comparison
+            half = observations.shape[0] // 2
+            if half == 0:
+                # If batch is too small, duplicate
+                return observations, observations
+            return observations[:half], observations[half : 2 * half]
+
+        # Has time dimension - use middle frames for stability
+        mid = observations.shape[1] // 2
+        obs1 = observations[:, mid, ...]  # (batch_size, *obs_shape)
+        obs2 = observations[:, mid - 1 if mid > 0 else 0, ...]
+
+        return obs1, obs2
+
+    @dispatch
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+        """Compute CTRL loss.
+
+        Args:
+            tensordict: Input tensordict containing observations.
+                Expected shape: (batch_size, [window_len], *obs_shape)
+
+        Returns:
+            TensorDict with keys:
+                - loss_ctrl: Total CTRL loss
+                - loss_proto: Prototype contrastive loss component
+                - loss_myow: MYOW cross-trajectory loss component
+        """
+        # Get observations
+        obs_key = self.tensor_keys.observation
+        observations = tensordict.get(obs_key)
+
+        if observations is None:
+            raise KeyError(
+                f"Could not find observation key '{obs_key}' in tensordict. "
+                f"Available keys: {list(tensordict.keys())}"
+            )
+
+        # Extract two sets of observations for comparison
+        obs1, obs2 = self._extract_windows(observations)
+
+        # Get embeddings from encoder
+        # Create temporary tensordicts for encoder forward pass
+        td1 = TensorDict({obs_key: obs1}, batch_size=obs1.shape[:1])
+        td2 = TensorDict({obs_key: obs2}, batch_size=obs2.shape[:1])
+
+        # Forward through encoder
+        with torch.set_grad_enabled(True):
+            td1 = self.encoder_network(td1)
+            td2 = self.encoder_network(td2)
+
+        emb_key = self.tensor_keys.embedding
+        z1_raw = td1.get(emb_key)
+        z2_raw = td2.get(emb_key)
+
+        if z1_raw is None:
+            raise KeyError(
+                f"Could not find embedding key '{emb_key}' in encoder output. "
+                f"Available keys: {list(td1.keys())}. "
+                f"Make sure the encoder network outputs to key '{emb_key}'."
+            )
+
+        # Project to prototype space
+        z1 = self.projection_head(z1_raw)
+        z2 = self.projection_head(z2_raw)
+
+        # Predict for contrastive loss
+        p1 = self.prediction_head(z1)
+        p2 = self.prediction_head(z2)
+
+        # Compute prototype contrastive loss (symmetric)
+        loss_proto_1 = self._compute_prototype_loss(z1.detach(), p2)
+        loss_proto_2 = self._compute_prototype_loss(z2.detach(), p1)
+        loss_proto = (loss_proto_1 + loss_proto_2) / 2
+
+        # Compute MYOW loss
+        loss_myow = self._compute_myow_loss(z1, z2)
+
+        # Total loss
+        loss_ctrl = loss_proto + self.myow_coeff * loss_myow
+
+        # Build output tensordict
+        td_out = TensorDict(
+            {
+                "loss_ctrl": loss_ctrl,
+                "loss_proto": loss_proto,
+                "loss_myow": loss_myow,
+            },
+        )
+
+        # Apply reduction
+        td_out = td_out.named_apply(
+            lambda name, value: _reduce(value, reduction=self.reduction)
+            if name.startswith("loss_")
+            else value,
+        )
+
+        return td_out
+
+
+class CTRLPPOLoss(LossModule):
+    """Combined CTRL and PPO loss for end-to-end training.
+
+    This module combines the ClipPPOLoss with CTRLLoss for joint training
+    of the policy and encoder representation. It provides a convenient wrapper
+    that handles both losses in a single forward pass.
+
+    Args:
+        ppo_loss (LossModule): The PPO loss module (e.g., ClipPPOLoss).
+        ctrl_loss (CTRLLoss): The CTRL loss module.
+
+    Keyword Args:
+        ctrl_coeff (float, optional): Coefficient for the CTRL loss term.
+            Defaults to 1.0.
+
+    Examples:
+        >>> from torchrl.objectives import ClipPPOLoss
+        >>> from torchrl.objectives.ctrl import CTRLLoss, CTRLPPOLoss
+        >>> # Create PPO and CTRL losses
+        >>> ppo_loss = ClipPPOLoss(actor, critic)
+        >>> ctrl_loss = CTRLLoss(encoder, embedding_dim=128)
+        >>> # Combine them
+        >>> combined_loss = CTRLPPOLoss(ppo_loss, ctrl_loss, ctrl_coeff=0.5)
+        >>> # Forward pass computes both losses
+        >>> loss_td = combined_loss(data)
+    """
+
+    @dataclass
+    class _AcceptedKeys:
+        """Accepted keys for CTRLPPOLoss."""
+
+        pass
+
+    default_keys = _AcceptedKeys
+
+    def __init__(
+        self,
+        ppo_loss: LossModule,
+        ctrl_loss: CTRLLoss,
+        *,
+        ctrl_coeff: float = 1.0,
+    ):
+        super().__init__()
+        self.ppo_loss = ppo_loss
+        self.ctrl_loss = ctrl_loss
+        self.register_buffer("ctrl_coeff", torch.tensor(ctrl_coeff))
+        self._in_keys = None
+        self._out_keys = None
+
+    @property
+    def functional(self):
+        return False
+
+    @property
+    def in_keys(self):
+        if self._in_keys is None:
+            self._in_keys = list(set(self.ppo_loss.in_keys + self.ctrl_loss.in_keys))
+        return self._in_keys
+
+    @property
+    def out_keys(self):
+        if self._out_keys is None:
+            self._out_keys = list(self.ppo_loss.out_keys) + list(
+                self.ctrl_loss.out_keys
+            )
+        return self._out_keys
+
+    def _forward_value_estimator_keys(self, **kwargs) -> None:
+        self.ppo_loss._forward_value_estimator_keys(**kwargs)
+
+    @dispatch
+    def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
+        """Compute combined PPO and CTRL losses.
+
+        Args:
+            tensordict: Input tensordict containing observations, actions, etc.
+
+        Returns:
+            TensorDict with all PPO loss keys plus CTRL loss keys.
+        """
+        # Compute PPO loss
+        td_ppo = self.ppo_loss(tensordict)
+
+        # Compute CTRL loss
+        td_ctrl = self.ctrl_loss(tensordict)
+
+        # Combine outputs
+        td_out = td_ppo.clone()
+        for key, value in td_ctrl.items():
+            td_out.set(key, value)
+
+        # Scale CTRL loss
+        if "loss_ctrl" in td_out.keys():
+            td_out.set("loss_ctrl", td_out.get("loss_ctrl") * self.ctrl_coeff)
+
+        return td_out
+
+    def make_value_estimator(self, *args, **kwargs):
+        """Forward to PPO loss value estimator."""
+        return self.ppo_loss.make_value_estimator(*args, **kwargs)


### PR DESCRIPTION
## Summary

This PR implements **CTRL (Cross-Trajectory Representation Learning)** from the paper:

**"Cross-Trajectory Representation Learning for Zero-Shot Generalization in RL"**
Mazoure et al., ICLR 2022 ([arXiv:2106.02193](https://arxiv.org/abs/2106.02193))

CTRL is a self-supervised representation learning method that improves zero-shot generalization in RL by training encoders to recognize behavioral similarity across trajectories.

### Components Added

- **`CTRLLoss`** (`torchrl/objectives/ctrl.py`): Standalone auxiliary loss module
  - Prototype-based contrastive learning using Sinkhorn algorithm for soft cluster assignments
  - MYOW (Make Your Own Winners) loss for cross-trajectory consistency
  - Configurable tensordict keys and hyperparameters
  - Compatible with any encoder network

- **`CTRLPPOLoss`**: Combined CTRL+PPO loss wrapper for joint training

- **SOTA Implementation** (`sota-implementations/ctrl/`):
  - `ctrl_procgen.py`: Complete training script for Procgen benchmark
  - `config.yaml`: Hydra configuration with all hyperparameters
  - `utils.py`: IMPALA-style encoder and environment utilities
  - `README.md`: Documentation with usage instructions

- **Comprehensive Tests** (`test/test_ctrl.py`):
  - 37 test cases covering forward pass, backward pass, hyperparameter variations
  - Sinkhorn algorithm validation
  - Combined CTRL+PPO loss testing

### Key Features

- Prototype-based contrastive learning without using rewards (avoids overfitting)
- MYOW loss encourages similar representations for behaviorally similar observations
- Designed for zero-shot generalization testing (Procgen benchmark)
- Easily integrated with existing PPO training pipelines

### Usage Example

```python
from torchrl.objectives import ClipPPOLoss
from torchrl.objectives.ctrl import CTRLLoss

# Create losses
ppo_loss = ClipPPOLoss(actor, critic)
ctrl_loss = CTRLLoss(encoder, embedding_dim=256)

# In training loop
loss_ppo = ppo_loss(data)
loss_ctrl = ctrl_loss(data)

# Optimize separately or jointly
```

## Test Plan

- [x] All 37 new tests pass (`pytest test/test_ctrl.py -v`)
- [x] Pre-commit checks pass (flake8, pydocstyle, pyupgrade, ufmt)
- [ ] Run training on Procgen to verify convergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)